### PR TITLE
ThinkPad Battery Widget

### DIFF
--- a/widgets/contrib/tpbat/init.lua
+++ b/widgets/contrib/tpbat/init.lua
@@ -30,7 +30,8 @@ local tpbat = { }
 local tpbat_notification = nil
 
 function tpbat:hide()
-    if tpbat_notification ~= nil then
+    if tpbat_notification ~= nil 
+    then
         naughty.destroy(tpbat_notification)
         tpbat_notification = nil
     end
@@ -49,8 +50,10 @@ function tpbat:show(t_out)
     local time   = bat:remaining_time()
     local msg    = "\t"
 
-    if status ~= "idle" and status ~= "nil" then
-        if time == "N/A" then
+    if status ~= "idle" and status ~= "nil" 
+    then
+        if time == "N/A" 
+        then
             msg = "...Calculating time remaining..."
         else
             msg = time .. (status == "charging" and " until charged" or " remaining")
@@ -80,7 +83,8 @@ function tpbat.register(args)
     
     tpbat.widget = wibox.widget.textbox('')
 
-    if bat:get('state') == nil then
+    if bat:get('state') == nil 
+    then
         local n = naughty.notify({
             title = "SMAPI Battery Warning: Unable to read battery state!",
             text = "This widget is intended for ThinkPads. Is tp_smapi installed? Check your configs & paths.",

--- a/widgets/contrib/tpbat/smapi.lua
+++ b/widgets/contrib/tpbat/smapi.lua
@@ -80,8 +80,9 @@ function smapi:battery(name)
         local time_val = bat_now.status == 'discharging' and 'remaining_running_time' or 'remaining_charging_time'
         local mins_left = self:get(time_val)
 
-        if mins_left:find("^%d+") == nil then
-            return "N/A"
+        if mins_left:find("^%d+") == nil 
+        then 
+            return "N/A" 
         end
         
         local hrs = mins_left / 60


### PR DESCRIPTION
A battery widget that works with Lenovo ThinkPad laptops using tp_smapi. Includes hover notification with more details. Configuration is identical to main bat widget's:

``` Lua
-- Battery
baticon = wibox.widget.imagebox(beautiful.widget_batt)
batwidget = lain.widgets.contrib.tpbat({ -- Use contrib.tpbat
    settings = function()
        if bat_now.perc == "N/A" then
            bat_now.perc = "AC "
        else
            bat_now.perc = bat_now.perc .. "% "
        end
        widget:set_text(bat_now.perc)
    end
})
```

I can provide screenshots, if needed, and a wiki entry. Let me know your thoughts. (tpbat.lua line 20 is a bit ugly)
