### PR TITLE
silence warnings when battery is <15%, but charging

### DIFF
--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -74,30 +74,33 @@ local function worker(args)
             bat_now.watt = string.format("%.2fW", (rate * ratev) / 1e12)
 
             -- notifications for low and critical states
-            if bat_now.perc <= 5
+            if bat_new.status == "Discharging"
             then
-                bat.id = naughty.notify({
-                    text = "shutdown imminent",
-                    title = "battery nearly exhausted",
-                    position = "top_right",
-                    timeout = 15,
-                    fg="#000000",
-                    bg="#ffffff",
-                    ontop = true,
-                    replaces_id = bat.id
-                }).id
-            elseif bat_now.perc <= 15
-            then
-                bat.id = naughty.notify({
-                    text = "plug the cable",
-                    title = "battery low",
-                    position = "top_right",
-                    timeout = 15,
-                    fg="#202020",
-                    bg="#cdcdcd",
-                    ontop = true,
-                    replaces_id = bat.id
-                }).id
+                if bat_now.perc <= 5
+                then
+                    bat.id = naughty.notify({
+                        text = "shutdown imminent",
+                        title = "battery nearly exhausted",
+                        position = "top_right",
+                        timeout = 15,
+                        fg="#000000",
+                        bg="#ffffff",
+                        ontop = true,
+                        replaces_id = bat.id
+                    }).id
+                elseif bat_now.perc <= 15
+                then
+                    bat.id = naughty.notify({
+                        text = "plug the cable",
+                        title = "battery low",
+                        position = "top_right",
+                        timeout = 15,
+                        fg="#202020",
+                        bg="#cdcdcd",
+                        ontop = true,
+                        replaces_id = bat.id
+                    }).id
+                end
             end
 
             bat_now.perc = string.format("%d", bat_now.perc)

--- a/widgets/contrib/tpbat/init.lua
+++ b/widgets/contrib/tpbat/init.lua
@@ -113,36 +113,39 @@ function tpbat.register(args)
 
         if bat:installed()
         then
-            bat_now.status = bat:status()
+            bat_now.status = bat:status() or "N/A"
             bat_now.perc   = bat:percent()
             bat_now.time   = bat:remaining_time()
             -- bat_now.watt = string.format("%.2fW", (VOLTS * AMPS) / 1e12)
 
-            -- notifications for low and critical states
-            if bat_now.perc <= 5
+            -- notifications for low and critical states (when discharging)
+            if bat_now.status == "discharging"
             then
-                tpbat.id = naughty.notify({
-                    text = "shutdown imminent",
-                    title = "battery nearly exhausted",
-                    position = "top_right",
-                    timeout = 15,
-                    fg="#000000",
-                    bg="#ffffff",
-                    ontop = true,
-                    replaces_id = tpbat.id
-                }).id
-            elseif bat_now.perc <= 15
-            then
-                tpbat.id = naughty.notify({
-                    text = "plug the cable",
-                    title = "battery low",
-                    position = "top_right",
-                    timeout = 15,
-                    fg="#202020",
-                    bg="#cdcdcd",
-                    ontop = true,
-                    replaces_id = tpbat.id
-                }).id
+                if bat_now.perc <= 5
+                then
+                    tpbat.id = naughty.notify({
+                        text = "shutdown imminent",
+                        title = "battery nearly exhausted",
+                        position = "top_right",
+                        timeout = 15,
+                        fg="#000000",
+                        bg="#ffffff",
+                        ontop = true,
+                        replaces_id = tpbat.id
+                    }).id
+                elseif bat_now.perc <= 15
+                then
+                    tpbat.id = naughty.notify({
+                        text = "plug the cable",
+                        title = "battery low",
+                        position = "top_right",
+                        timeout = 15,
+                        fg="#202020",
+                        bg="#cdcdcd",
+                        ontop = true,
+                        replaces_id = tpbat.id
+                    }).id
+                end
             end
 
             bat_now.perc = tostring(bat_now.perc)


### PR DESCRIPTION
After allowing my laptop to deplete its battery, I connected the laptop to power and started it up. Upon login, I was notified each refresh interval that battery death was imminent (despite being on AC power). This commit silences battery warnings unless the battery is discharging (applied for both the original bat widget and the contrib.tpbat widget).
