### PR TITLE
Change io.popen to io.open so we don't execute image files.

### DIFF
--- a/widgets/yawn/init.lua
+++ b/widgets/yawn/init.lua
@@ -1,4 +1,3 @@
-
 --[[
                                                   
      Licensed under GNU General Public License v2 
@@ -115,7 +114,7 @@ local function fetch_weather()
     sky = sky  .. forecast:gsub(" ", ""):gsub("/", "") .. ".png"
 
     -- In case there's no defined icon for current forecast
-    f = io.popen(sky)
+    f = io.open(sky)
     if f == nil then
         sky = icon_path .. "na.png"
     else


### PR DESCRIPTION
Doesn't affect how the script runs, but I was getting annoyed at the error in my .xsession-errors. Probably not a good idea to execute a binary file anyway for security purposes.
