### PR TITLE
Fix imap unread count

### DIFF
--- a/widgets/imap.lua
+++ b/widgets/imap.lua
@@ -62,6 +62,7 @@ local function worker(args)
         f:close()
 
         _, mailcount = string.gsub(ws, "%d+", "")
+        _ = nil
 
         widget = imap.widget
         settings()


### PR DESCRIPTION
I recognized that the imap widget was counting the digets in the imap response instead of the message ids, i also removed the `tonumber()` call on `mailcount` since `string.gsub` already returns a number, even if no match was replaced it'll return a `0`
