### PR TITLE
be able to switch notifications off for bat widget

### DIFF
--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -110,7 +110,7 @@ local function worker(args)
                         ontop = true,
                         replaces_id = bat.id
                     }).id
-                elseif tonumber(bat_now.perc) <= 80
+                elseif tonumber(bat_now.perc) <= 15
                 then
                     bat.id = naughty.notify({
                         text = "plug the cable",


### PR DESCRIPTION
I included a variable "notify" which can be set to "off" in which case there are no notifications for the bat widget. I found those notifications a bit too much since they start at 15% bat power. So I included a simply possibility to set notify "off".

Let me know if you have any other ideas, one could include more variables to set the percentage at which notifications appear but in this case, I would have had to overwrite cahna's code which fixes the limits at 15% and 5%.

EDIT: I also added the variable to the wiki on my github, but it seems wikis cannot be pull requested (sorry, newbie to github).
