### PR TITLE
use awful.tag.gettags in order to keep compatibility with custom configs...

### DIFF
--- a/util/init.lua
+++ b/util/init.lua
@@ -146,7 +146,7 @@ function util.tag_view_nonempty(direction, sc)
    local s = sc or mouse.screen or 1
    local scr = screen[s]
 
-   for i = 1, #tags[s] do
+   for i = 1, #awful.tag.gettags(s) do
        awful.tag.viewidx(direction,s)
        if #awful.client.visible(s) > 0 then
            return


### PR DESCRIPTION
Hey there,
I have integrated tyrannical in your set of themes, and it appeared that util.tag_view_nonempty failed because it was referring to "tags" object (which does not exist) instead of asking awful for the list of tags (awful.tag.gettags())

this patche just fixes compatibility between lain and  tyrannical.

Regards,
 kamou
