### PR TITLE
ask df for a specific filesystem

### DIFF
--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -67,7 +67,7 @@ local function worker(args)
         fs_info = {}
         fs_now  = {}
 
-        local f = io.popen("LC_ALL=C df -kP")
+        local f = io.popen("LC_ALL=C df -kP " .. partition)
 
         for line in f:lines() do -- Match: (size) (used)(avail)(use%) (mount)
             local s     = string.match(line, "^.-[%s]([%d]+)")


### PR DESCRIPTION
POSIX df supports requesting a single filesystem, so doing so will ensure that df can only get stuck if the filesystem we requested is in a hung state.
