### PR TITLE
fix cpu load calculation

### DIFF
--- a/widgets/cpu.lua
+++ b/widgets/cpu.lua
@@ -43,9 +43,9 @@ local function worker(args)
         local total = 0
         for field in string.gmatch(times, "[%s]+([^%s]+)")
         do
-            -- 3 = idle, 4 = ioWait. Essentially, the CPUs have done
+            -- 4 = idle, 5 = ioWait. Essentially, the CPUs have done
             -- nothing during these times.
-            if at == 3 or at == 4
+            if at == 4 or at == 5
             then
                 idle = idle + field
             end


### PR DESCRIPTION
The `cpuwidget` considers _system load_ (i.e. time spent in kernel mode) as idle time, probably due to a simple array subscript typo (indexing from 0 instead of 1). This causes the widget to show less CPU utilisation than it is supposed to.

For **example**, a workload that causes 75% user-space and 25% kernel-space load will be reported as 75% CPU utilisation by the widget.

See `proc(5)` for more.
