### PR TITLE
show notification window in focused screen

### DIFF
--- a/widgets/alsabar.lua
+++ b/widgets/alsabar.lua
@@ -54,22 +54,22 @@ local alsabar =
 function alsabar.notify()
   alsabar.update()
 
-	local preset =
-	{
+    local preset =
+    {
       title   = "",
       text    = "",
       timeout = 4,
       font    = alsabar.notifications.font .. " " ..
                 alsabar.notifications.font_size,
       fg      = alsabar.notifications.color
-	}
+    }
 
-	if alsabar._muted
+    if alsabar._muted
   then
-		preset.title = alsabar.channel .. " - Muted"
-	else
-		preset.title = alsabar.channel .. " - " .. alsabar._current_level * 100 .. "%"
-	end
+        preset.title = alsabar.channel .. " - Muted"
+    else
+        preset.title = alsabar.channel .. " - " .. alsabar._current_level * 100 .. "%"
+    end
 
   int = math.modf(alsabar._current_level * alsabar.notifications.bar_size)
   preset.text = "["
@@ -78,15 +78,17 @@ function alsabar.notify()
                 .. "]"
 
   if alsabar._notify ~= nil then
-		alsabar._notify = naughty.notify ({
+        alsabar._notify = naughty.notify ({
         replaces_id = alsabar._notify.id,
-			  preset      = preset
+        preset      = preset,
+        screen = client.focus and client.focus.screen or 1
     })
-	else
-		alsabar._notify = naughty.notify ({
-        preset = preset
+    else
+        alsabar._notify = naughty.notify ({
+        preset = preset,
+        screen = client.focus and client.focus.screen or 1
     })
-	end
+    end
 end
 
 local function worker(args)

--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -129,13 +129,15 @@ local function worker(args)
             then
                 bat.id = naughty.notify({
                     preset = bat_notification_critical_preset,
-                    replaces_id = bat.id
+                    replaces_id = bat.id,
+                    screen = client.focus and client.focus.screen or 1
                 }).id
             elseif nperc <= 15
             then
                 bat.id = naughty.notify({
                     preset = bat_notification_low_preset,
-                    replaces_id = bat.id
+                    replaces_id = bat.id,
+                    screen = client.focus and client.focus.screen or 1
                 }).id
             end
         end

--- a/widgets/calendar.lua
+++ b/widgets/calendar.lua
@@ -98,7 +98,8 @@ function calendar:show(t_out, inc_offset)
         position = calendar.position,
         fg = calendar.fg,
         bg = calendar.bg,
-        timeout = tims
+        timeout = tims,
+        screen = client.focus and client.focus.screen or 1
     })
 end
 

--- a/widgets/contrib/task.lua
+++ b/widgets/contrib/task.lua
@@ -51,7 +51,9 @@ function task:show()
                                          position = task.position,
                                          fg = task.fg,
                                          bg = task.bg,
-                                         timeout = task.timeout })
+                                         timeout = task.timeout,
+                                         screen = client.focus and client.focus.screen or 1
+                                     })
 end
 
 function task:prompt_add()
@@ -72,7 +74,8 @@ function task:prompt_add()
               position = task.position,
               fg       = task.fg,
               bg       = task.bg,
-              timeout  = task.timeout
+              timeout  = task.timeout,
+              screen = client.focus and client.focus.screen or 1
           })
       end,
       nil,
@@ -105,7 +108,8 @@ function task:prompt_search()
               position = task.position,
               fg       = task.fg,
               bg       = task.bg,
-              timeout  = task.timeout
+              timeout  = task.timeout,
+              screen = client.focus and client.focus.screen or 1
           })
       end,
       nil,

--- a/widgets/contrib/tpbat/init.lua
+++ b/widgets/contrib/tpbat/init.lua
@@ -75,7 +75,8 @@ function tpbat:show(t_out)
     tpbat_notification = naughty.notify({
         preset = { fg = beautiful.fg_normal },
         text = str,
-        timeout = t_out
+        timeout = t_out,
+        screen = client.focus and client.focus.screen or 1
     })
 end
 
@@ -111,7 +112,8 @@ function tpbat.register(args)
         local n = naughty.notify({
             preset = bat_notification_low_preset,
             title = "SMAPI Battery Warning: Unable to read battery state!",
-            text = "This widget is intended for ThinkPads. Is tp_smapi installed? Check your configs & paths."
+            text = "This widget is intended for ThinkPads. Is tp_smapi installed? Check your configs & paths.",
+            screen = client.focus and client.focus.screen or 1
         })
     end
 
@@ -137,13 +139,15 @@ function tpbat.register(args)
                 then
                     tpbat.id = naughty.notify({
                         preset = bat_notification_critical_preset,
-                        replaces_id = tpbat.id
+                        replaces_id = tpbat.id,
+                        screen = client.focus and client.focus.screen or 1
                     }).id
                 elseif bat_now.perc <= 15
                 then
                     tpbat.id = naughty.notify({
                         preset = bat_notification_low_preset,
-                        replaces_id = tpbat.id
+                        replaces_id = tpbat.id,
+                        screen = client.focus and client.focus.screen or 1
                     }).id
                 end
             end

--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -46,7 +46,8 @@ function fs:show(t_out)
     notification = naughty.notify({
         preset = fs_notification_preset,
         text = ws,
-      	timeout = t_out
+        timeout = t_out,
+        screen = client.focus and client.focus.screen or 1
     })
 end
 
@@ -66,7 +67,6 @@ local function worker(args)
     function update()
         fs_info = {}
         fs_now  = {}
-
         local f = io.popen("LC_ALL=C df -kP " .. partition)
 
         for line in f:lines() do -- Match: (size) (used)(avail)(use%) (mount)
@@ -99,7 +99,8 @@ local function worker(args)
                 text = partition .. " ran out!\nmake some room",
                 timeout = 8,
                 fg = "#000000",
-                bg = "#FFFFFF"
+                bg = "#FFFFFF",
+                screen = client.focus and client.focus.screen or 1
             })
             helpers.set_map("fs", true)
         else

--- a/widgets/imap.lua
+++ b/widgets/imap.lua
@@ -74,7 +74,11 @@ local function worker(args)
             else
                 nt = mail .. " has <b>" .. mailcount .. "</b> new messages"
             end
-            naughty.notify({ preset = mail_notification_preset, text = nt })
+            naughty.notify({
+                preset = mail_notification_preset,
+                text = nt,
+                screen = client.focus and client.focus.screen or 1
+            })
         end
 
         helpers.set_map(mail, mailcount)

--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -92,7 +92,8 @@ local function worker(args)
                 mpd.id = naughty.notify({
                     preset = mpd_notification_preset,
                     icon = "/tmp/mpdcover.png",
-                    replaces_id = mpd.id
+                    replaces_id = mpd.id,
+                    screen = client.focus and client.focus.screen or 1
                 }).id
             end
         elseif mpd_now.state ~= "pause"

--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -87,7 +87,8 @@ local function worker(args)
                     timeout  = 7,
                     position = "top_left",
                     icon     = helpers.icons_dir .. "no_net.png",
-                    fg       = notify_fg or "#FFFFFF"
+                    fg       = notify_fg or "#FFFFFF",
+                    screen = client.focus and client.focus.screen or 1
                 })
                 helpers.set_map(iface, false)
             end

--- a/widgets/yawn/init.lua
+++ b/widgets/yawn/init.lua
@@ -161,7 +161,8 @@ function yawn.show(t_out)
         preset = yawn_notification_preset,
         text = weather_data,
         icon = sky,
-        timeout = t_out
+        timeout = t_out,
+        screen = client.focus and client.focus.screen or 1
     })
 end
 


### PR DESCRIPTION
As title says, notifications should be popped in focused screen, especially for mouse over triggered window.
Predicating `client.focus` is for notifications sent at startup, during which it's not set seemingly. 
