### PR TITLE
layout.centerwork: Use the first client (master) as the central window.

### DIFF
--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -37,7 +37,7 @@ function centerwork.arrange(p)
     if #cls > 0
     then
         -- Main column, fixed width and height.
-        local c = cls[#cls]
+        local c = cls[1]
         local g = {}
         local mainwid = math.floor(wa.width * mwfact)
         local slavewid = wa.width - mainwid
@@ -57,7 +57,7 @@ function centerwork.arrange(p)
         if #cls > 1
         then
             local at = 0
-            for i = (#cls - 1),1,-1
+            for i = (#cls),2,-1
             do
                 -- It's all fixed. If there are more than 5 clients,
                 -- those additional clients will float. This is


### PR DESCRIPTION
Set the first client in the clients list as the central window in the layout.

It makes sense for the master client to be in the center. This can be used in various
ways for instance to switch positions of a slave window with the master window.

A side effect of this is that if you have the central window selected and you open
a new client the central window does not change locations.
