### PR TITLE
open notification on mouse.screen

### DIFF
--- a/widgets/alsabar.lua
+++ b/widgets/alsabar.lua
@@ -77,12 +77,12 @@ function alsabar.notify()
         alsabar._notify = naughty.notify ({
             replaces_id = alsabar._notify.id,
             preset      = preset,
-            screen = client.focus and client.focus.screen or 1
+            screen = mouse.screen
         })
     else
         alsabar._notify = naughty.notify ({
             preset = preset,
-            screen = client.focus and client.focus.screen or 1
+            screen = mouse.screen
         })
     end
 end

--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -130,14 +130,14 @@ local function worker(args)
                 bat.id = naughty.notify({
                     preset = bat_notification_critical_preset,
                     replaces_id = bat.id,
-                    screen = client.focus and client.focus.screen or 1
+                    screen = mouse.screen
                 }).id
             elseif nperc <= 15
             then
                 bat.id = naughty.notify({
                     preset = bat_notification_low_preset,
                     replaces_id = bat.id,
-                    screen = client.focus and client.focus.screen or 1
+                    screen = mouse.screen
                 }).id
             end
         end

--- a/widgets/calendar.lua
+++ b/widgets/calendar.lua
@@ -99,7 +99,7 @@ function calendar:show(t_out, inc_offset)
         fg = calendar.fg,
         bg = calendar.bg,
         timeout = tims,
-        screen = client.focus and client.focus.screen or 1
+        screen = mouse.screen
     })
 end
 

--- a/widgets/contrib/task.lua
+++ b/widgets/contrib/task.lua
@@ -52,7 +52,7 @@ function task:show()
                                          fg = task.fg,
                                          bg = task.bg,
                                          timeout = task.timeout,
-                                         screen = client.focus and client.focus.screen or 1
+                                         screen = mouse.screen
                                      })
 end
 
@@ -75,7 +75,7 @@ function task:prompt_add()
               fg       = task.fg,
               bg       = task.bg,
               timeout  = task.timeout,
-              screen = client.focus and client.focus.screen or 1
+              screen = mouse.screen
           })
       end,
       nil,
@@ -109,7 +109,7 @@ function task:prompt_search()
               fg       = task.fg,
               bg       = task.bg,
               timeout  = task.timeout,
-              screen = client.focus and client.focus.screen or 1
+              screen = mouse.screen
           })
       end,
       nil,

--- a/widgets/contrib/tpbat/init.lua
+++ b/widgets/contrib/tpbat/init.lua
@@ -76,7 +76,7 @@ function tpbat:show(t_out)
         preset = { fg = beautiful.fg_normal },
         text = str,
         timeout = t_out,
-        screen = client.focus and client.focus.screen or 1
+        screen = mouse.screen
     })
 end
 
@@ -113,7 +113,7 @@ function tpbat.register(args)
             preset = bat_notification_low_preset,
             title = "SMAPI Battery Warning: Unable to read battery state!",
             text = "This widget is intended for ThinkPads. Is tp_smapi installed? Check your configs & paths.",
-            screen = client.focus and client.focus.screen or 1
+            screen = mouse.screen
         })
     end
 
@@ -140,14 +140,14 @@ function tpbat.register(args)
                     tpbat.id = naughty.notify({
                         preset = bat_notification_critical_preset,
                         replaces_id = tpbat.id,
-                        screen = client.focus and client.focus.screen or 1
+                        screen = mouse.screen
                     }).id
                 elseif bat_now.perc <= 15
                 then
                     tpbat.id = naughty.notify({
                         preset = bat_notification_low_preset,
                         replaces_id = tpbat.id,
-                        screen = client.focus and client.focus.screen or 1
+                        screen = mouse.screen
                     }).id
                 end
             end

--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -47,7 +47,7 @@ function fs:show(t_out)
         preset = fs_notification_preset,
         text = ws,
         timeout = t_out,
-        screen = client.focus and client.focus.screen or 1
+        screen = mouse.screen
     })
 end
 
@@ -100,7 +100,7 @@ local function worker(args)
                 timeout = 8,
                 fg = "#000000",
                 bg = "#FFFFFF",
-                screen = client.focus and client.focus.screen or 1
+                screen = mouse.screen
             })
             helpers.set_map("fs", true)
         else

--- a/widgets/imap.lua
+++ b/widgets/imap.lua
@@ -77,7 +77,7 @@ local function worker(args)
                 naughty.notify({
                     preset = mail_notification_preset,
                     text = nt,
-                    screen = client.focus and client.focus.screen or 1
+                    screen = mouse.screen
                 })
             end
 

--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -91,7 +91,7 @@ local function worker(args)
                         preset = mpd_notification_preset,
                         icon = "/tmp/mpdcover.png",
                         replaces_id = mpd.id,
-                        screen = client.focus and client.focus.screen or 1
+                        screen = mouse.screen
                     }).id
                 end
             elseif mpd_now.state ~= "pause"

--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -88,7 +88,7 @@ local function worker(args)
                     position = "top_left",
                     icon     = helpers.icons_dir .. "no_net.png",
                     fg       = notify_fg or "#FFFFFF",
-                    screen = client.focus and client.focus.screen or 1
+                    screen = mouse.screen
                 })
                 helpers.set_map(iface, false)
             end

--- a/widgets/yawn/init.lua
+++ b/widgets/yawn/init.lua
@@ -167,7 +167,7 @@ function yawn.show(t_out)
         text = weather_data,
         icon = sky,
         timeout = t_out,
-        screen = client.focus and client.focus.screen or 1
+        screen = mouse.screen
     })
 end
 


### PR DESCRIPTION
Notification were occasionally opened on the wrong screen when using the
mouse to hover over a widget.

It is possible to have the mouse on a different screen than the focused
client by actively moving the mouse from screen to screen without
leaving the topbar. Switching screens with the keyboard binding will
also jump the mouse to the new screen. Therefore, using 'mouse.screen'
instead of 'client.focus.screen' will always open the notification on
the correct screen. 'mouse.screen' should always be defined (correct me
if I'm wrong), so no need for 'or 1'.

This was tested for the calendar widget only, the other ones where
replaced with sed and some care but are untested.

Side note:
On the other hand, it might be even better to be able to pass screen as
an argument when creating/showing the widget. This is especially usefull
when showing the widget via keyboard binding.
