### PR TITLE
fixed mount point length calculation and misalignment of 4-digit size numbers

### DIFF
--- a/scripts/dfs
+++ b/scripts/dfs
@@ -107,7 +107,7 @@ fi
 #   Computing mount point max length
 # -------------------------------------------------------------------------
 MOUNT_POINT_MAX_LENGTH=` \
-											 echo $SORTED_FILE_SYSTEMS_INFO | $AWK_COMMAND -v PATTERN=$PATTERN \
+											 echo "$SORTED_FILE_SYSTEMS_INFO" | $AWK_COMMAND -v PATTERN=$PATTERN \
 											 '
 											 BEGIN       {
 												 mount_point_length_max = 15;
@@ -364,22 +364,22 @@ $0 ~ PATTERN    {
 
 			if (total_size > 1 * t_bytes)
 				printf ( \
-						"| %3d%%    %5.1f    %5.1f Tb\n", \
+						"| %3d%%   %6.1f   %6.1f Tb\n", \
 						percentage_occupied, free_size / t_bytes, total_size / t_bytes \
 						);
 			else if (total_size > 1 * g_bytes)
 				printf ( \
-						"| %3d%%    %5.1f    %5.1f Gb\n", \
+						"| %3d%%   %6.1f   %6.1f Gb\n", \
 						percentage_occupied, free_size / g_bytes, total_size / g_bytes \
 						);
 			else if (total_size > 1 * m_byptes)
 				printf ( \
-						"| %3d%%    %5.1f    %5.1f Mb\n", \
+						"| %3d%%   %6.1f   %6.1f Mb\n", \
 						percentage_occupied, free_size / m_bytes, total_size / m_bytes \
 						);
 			else
 				printf ( \
-						"| %3d%%    %5.1f    %5.1f Kb\n", \
+						"| %3d%%   %6.1f   %6.1f Kb\n", \
 						percentage_occupied, free_size / k_bytes, total_size / k_bytes \
 						);
 		}


### PR DESCRIPTION
Before:
```
                                                                      Used    Free     Total 

/                |************-------------------------------------|  24%     21.4     29.4 Gb
/boot            |*------------------------------------------------|   3%    996.4    1022.0 Mb
/dev             |-------------------------------------------------|   0%      1.9      1.9 Gb
/dev/shm         |*------------------------------------------------|   2%      1.8      1.9 Gb
/home            |**************************************-----------|  77%     33.2    147.5 Gb
/home/johndoe/Storage|*********----------------------------------------|  19%    201.5    260.7 Gb
/run             |-------------------------------------------------|   1%      1.9      1.9 Gb
/run/user/1000   |-------------------------------------------------|   1%    380.4    380.5 Mb
/sys/fs/cgroup   |-------------------------------------------------|   0%      1.9      1.9 Gb
/tmp             |-------------------------------------------------|   1%      1.9      1.9 Gb
/var             |***************************----------------------|  55%      7.6     17.6 Gb
                 |----|----|----|----|----|----|----|----|----|----|
                 0   10   20   30   40   50   60   70   80   90  100
```

After:
```
                                                                            Used    Free     Total 

/                      |************-------------------------------------|  24%     21.4     29.4 Gb
/boot                  |*------------------------------------------------|   3%    996.4   1022.0 Mb
/dev                   |-------------------------------------------------|   0%      1.9      1.9 Gb
/dev/shm               |*------------------------------------------------|   2%      1.8      1.9 Gb
/home                  |**************************************-----------|  77%     33.2    147.5 Gb
/home/johndoe/Storage  |*********----------------------------------------|  19%    201.5    260.7 Gb
/run                   |-------------------------------------------------|   1%      1.9      1.9 Gb
/run/user/1000         |-------------------------------------------------|   1%    380.4    380.5 Mb
/sys/fs/cgroup         |-------------------------------------------------|   0%      1.9      1.9 Gb
/tmp                   |-------------------------------------------------|   1%      1.9      1.9 Gb
/var                   |***************************----------------------|  55%      7.6     17.6 Gb
                       |----|----|----|----|----|----|----|----|----|----|
                       0   10   20   30   40   50   60   70   80   90  100
```

Maybe there will be problems if someone e.g. decides to have a 500-char path to a mount point but hopefully nobody does that.