### PR TITLE
Added keys to mpd_now for querying the length of a song and the current time

### DIFF
--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -58,7 +58,9 @@ local function worker(args)
                 artist = "N/A",
                 title  = "N/A",
                 album  = "N/A",
-                date   = "N/A"
+                date   = "N/A",
+                time   = "N/A",
+                elapsed= "N/A"
             }
 
             for line in f:lines() do
@@ -69,6 +71,8 @@ local function worker(args)
                     elseif k == "Title"  then mpd_now.title  = escape_f(v)
                     elseif k == "Album"  then mpd_now.album  = escape_f(v)
                     elseif k == "Date"   then mpd_now.date   = escape_f(v)
+                    elseif k == "Time"   then mpd_now.time   = v
+                    elseif k == "elapsed"then mpd_now.elapsed= math.floor(v)
                     end
                 end
             end


### PR DESCRIPTION
I added functionality to the mpd widget by extending the mpd_now table with keys `mpd_now.elapsed` and `mpd_now.time`, which give the current time in the song and the total length of the current song respectively, in seconds. This is some code from my rc.lua that uses the widget:

```
-- Represent a number of seconds as a string of minutes:seconds.
function format_time(s)
   return string.format("%d:%.2d", math.floor(s/60), s%60)
end

-- Add an mpd widget
mpdwidget = lain.widgets.mpd({
      settings = function()
         local artist = mpd_now.artist
         local title = mpd_now.title
         local state = ""
         local time = ""
         if mpd_now.time ~= "N/A" and
         mpd_now.elapsed ~= "N/A" then
            time = " (" .. format_time(mpd_now.elapsed) .. "/" ..
               format_time(mpd_now.time) .. ")"
         end
         if mpd_now.state == "pause" then
            state = "[Paused] "
         elseif mpd_now.state == "play" then
            state = "[Playing] "
         end
         widget:set_markup(" " .. state .. artist .. " - " .. title .. time .. " ")
      end})
```

Example output: `[Playing] Danger Mouse - What More Can I Say (1:29/4:25)`