### PR TITLE
Fix in calendar

### DIFF
--- a/widgets/calendar.lua
+++ b/widgets/calendar.lua
@@ -37,7 +37,7 @@ function calendar:show(t_out, inc_offset, scr)
     local tims = t_out or 0
     local f, c_text
     local today = tonumber(os.date('%d'))
-    local init_t = calendar.cal .. ' | sed -r -e "s/(^| )( '
+    local init_t = calendar.cal .. ' | sed -r -e "s/_\\x08//g" | sed -r -e "s/(^| )( '
 
     calendar.offset = calendar.offset + offs
 


### PR DESCRIPTION
Hi! I'm doing this change because in some distributions (i.e ubuntu 14.04) without the regex clean you can't appreciate the highlight of the current date and you see strange symbols.

Look attached screenshots:

Previous to the change:
![previous](https://cloud.githubusercontent.com/assets/3705212/6024215/42f76256-aba8-11e4-8460-8ee0f32b1f35.png)

After the change:
![after](https://cloud.githubusercontent.com/assets/3705212/6024214/42ee5fe4-aba8-11e4-9fa0-f015f33c5536.png)