### PR TITLE
Add a card attribute for alsa and alsabar

### DIFF
--- a/widgets/alsa.lua
+++ b/widgets/alsa.lua
@@ -12,7 +12,8 @@ local newtimer        = require("lain.helpers").newtimer
 local wibox           = require("wibox")
 
 local io              = { popen  = io.popen }
-local string          = { match  = string.match }
+local string          = { match  = string.match,
+                          format = string.format }
 
 local setmetatable    = setmetatable
 
@@ -22,6 +23,7 @@ local alsa = {}
 
 local function worker(args)
     local args     = args or {}
+    local card     = args.card or "0"
     local timeout  = args.timeout or 5
     local channel  = args.channel or "Master"
     local settings = args.settings or function() end
@@ -29,7 +31,7 @@ local function worker(args)
     alsa.widget = wibox.widget.textbox('')
 
     function alsa.update()
-        local f = assert(io.popen('amixer -M get ' .. channel))
+        local f = assert(io.popen(string.format("amixer -c %s -M get %s", card, channel)))
         local mixer = f:read("*a")
         f:close()
 

--- a/widgets/alsabar.lua
+++ b/widgets/alsabar.lua
@@ -25,6 +25,7 @@ local setmetatable = setmetatable
 -- ALSA volume bar
 -- lain.widgets.alsabar
 local alsabar = {
+    card    = "0",
     channel = "Master",
     step    = "5%",
 
@@ -97,6 +98,7 @@ local function worker(args)
     local ticks_size = args.ticks_size or 7
     local vertical = args.vertical or false
 
+    alsabar.card = args.card or alsabar.card
     alsabar.channel = args.channel or alsabar.channel
     alsabar.step = args.step or alsabar.step
     alsabar.colors = args.colors or alsabar.colors
@@ -115,7 +117,7 @@ local function worker(args)
 
     function alsabar.update()
         -- Get mixer control contents
-        local f = io.popen("amixer -M get " .. alsabar.channel)
+        local f = assert(io.popen(string.format("amixer -c %s -M get %s", alsabar.card, alsabar.channel)))
         local mixer = f:read("*a")
         f:close()
 
@@ -129,7 +131,6 @@ local function worker(args)
 
         alsabar._current_level = tonumber(volu)
         alsabar.bar:set_value(alsabar._current_level / 100)
-
         if not mute and tonumber(volu) == 0 or mute == "off"
         then
             alsabar._muted = true
@@ -154,15 +155,15 @@ local function worker(args)
             awful.util.spawn(alsabar.mixer)
           end),
           awful.button ({}, 3, function()
-            awful.util.spawn(string.format("amixer set %s toggle", alsabar.channel))
+            awful.util.spawn(string.format("amixer -c %s set %s toggle", alsabar.card, alsabar.channel))
             alsabar.update()
           end),
           awful.button ({}, 4, function()
-            awful.util.spawn(string.format("amixer set %s %s+", alsabar.channel, alsabar.step))
+            awful.util.spawn(string.format("amixer -c %s set %s %s+", alsabar.card, alsabar.channel, alsabar.step))
             alsabar.update()
           end),
           awful.button ({}, 5, function()
-            awful.util.spawn(string.format("amixer set %s %s-", alsabar.channel, alsabar.step))
+            awful.util.spawn(string.format("amixer -c %s set %s %s-", alsabar.card, alsabar.channel, alsabar.step))
             alsabar.update()
           end)
     ))


### PR DESCRIPTION
Currently alsa.lua and alsabar.lua do not support the amixer command
line option "-c" which allows defining which card to use. For at
least new Dell E-series laptops, the card is not the default (0) and
therefore this functionality is required for these widgets to work.