### PR TITLE
smapi: round remaining hour estimation

### DIFF
--- a/widgets/contrib/tpbat/smapi.lua
+++ b/widgets/contrib/tpbat/smapi.lua
@@ -87,7 +87,7 @@ function smapi:battery(name)
             return "N/A"
         end
 
-        local hrs = mins_left / 60
+        local hrs = math.floor(mins_left / 60)
         local min = mins_left % 60
         return string.format("%02d:%02d", hrs, min)
     end


### PR DESCRIPTION
For some reason my awesome installation began to complain that lua could not convert the hour value to an integer format.

I'm using:
> awesome v3.5.6 (For Those About To Rock)
 • Build: May  5 2015 05:45:29 for x86_64 by gcc version 5.1.0 (builduser@)
 • Compiled against Lua 5.3.0 (running with Lua 5.3)
 • D-Bus support: ✔