### PR TITLE
Optionally disable mapped volume output

### DIFF
--- a/widgets/alsa.lua
+++ b/widgets/alsa.lua
@@ -28,11 +28,12 @@ local function worker(args)
 
     alsa.card    = args.card or "0"
     alsa.channel = args.channel or "Master"
+    alsa.mapped  = args.mapped or "-M"
 
     alsa.widget = wibox.widget.textbox('')
 
     function alsa.update()
-        local f = assert(io.popen(string.format("amixer -c %s -M get %s", alsa.card, alsa.channel)))
+        local f = assert(io.popen(string.format("amixer -c %s %s get %s", alsa.card, alsa.mapped, alsa.channel)))
         local mixer = f:read("*a")
         f:close()
 

--- a/widgets/alsabar.lua
+++ b/widgets/alsabar.lua
@@ -28,6 +28,7 @@ local alsabar = {
     card    = "0",
     channel = "Master",
     step    = "2%",
+    mapped  = "-M",
 
     colors = {
         background = beautiful.bg_normal,
@@ -98,6 +99,7 @@ local function worker(args)
 
     alsabar.card = args.card or alsabar.card
     alsabar.channel = args.channel or alsabar.channel
+    alsabar.mapped  = args.mapped or alsabar.mapped
     alsabar.step = args.step or alsabar.step
     alsabar.colors = args.colors or alsabar.colors
     alsabar.notifications = args.notifications or alsabar.notifications
@@ -115,7 +117,7 @@ local function worker(args)
 
     function alsabar.update()
         -- Get mixer control contents
-        local f = assert(io.popen(string.format("amixer -c %s -M get %s", alsabar.card, alsabar.channel)))
+        local f = assert(io.popen(string.format("amixer -c %s %s get %s", alsabar.card, alsabar.mapped, alsabar.channel)))
         local mixer = f:read("*a")
         f:close()
 


### PR DESCRIPTION
The ``-M`` option in amixer may be unintuitive for some users.
Allow disabling it by passing an empty string as the value of mapped.

The default behaviour is to use ``-M`` to keep backwards compatibility.