### PR TITLE
fixing small typo in fs widget which lead to nil reference

### DIFF
--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -106,8 +106,8 @@ local function worker(args)
         end
     end
 
-    widget:connect_signal('mouse::enter', function () fs:show(0) end)
-    widget:connect_signal('mouse::leave', function () fs:hide() end)
+    fs.widget:connect_signal('mouse::enter', function () fs:show(0) end)
+    fs.widget:connect_signal('mouse::leave', function () fs:hide() end)
 
     helpers.newtimer(partition, timeout, update)
 


### PR DESCRIPTION
In the last commit, there was a typo in lines 109/110 from ```fs``` widget which trying to add events to a 'null' widget. It happens because actual widget belong to ```fs``` table, and these lines didn't had the ```fs.``` prefix to the widget. 

Pulling small fix to it.