### PR TITLE
Asyncshell now works without temporary files

### DIFF
--- a/asyncshell.lua
+++ b/asyncshell.lua
@@ -43,10 +43,9 @@ function asyncshell.request(command, callback, timeout)
     asyncshell.request_table[id] = { callback = callback }
 
     local formatted_command = string.gsub(command, '"','\"')
-                              .. " | sed -e 's/\"/\\\\\"/g' -e ':a;N;$!ba;s/\\n/\\\\n/g'"
 
     local req = string.format(
-        "echo \"asyncshell.deliver(%s, \\\"$(%s)\\\")\" | awesome-client &",
+        "echo \"asyncshell.deliver(%s, [[\\\"$(%s)\\\"]])\" | awesome-client &",
         id, formatted_command
     )
 
@@ -63,6 +62,7 @@ end
 -- @param id Request ID
 -- @param output Shell command output to be delievered
 function asyncshell.deliver(id, output)
+	local output = string.sub(output, 2, -2)
     if asyncshell.request_table[id] then
         asyncshell.request_table[id].callback(output)
         asyncshell.clear(id)

--- a/asyncshell.lua
+++ b/asyncshell.lua
@@ -1,79 +1,72 @@
 
 --[[
-                                                  
-     Licensed under GNU General Public License v2 
-      * (c) 2013, Alexander Yakushev              
-                                                  
+
+     Licensed under GNU General Public License v2
+      * (c) 2015, worron
+      * (c) 2013, Alexander Yakushev
+
 --]]
 
 -- Asynchronous io.popen for Awesome WM.
--- How to use...
--- ...asynchronously:
--- asyncshell.request('wscript -Kiev', function(f) wwidget.text = f:read("*l") end)
--- ...synchronously:
--- widget:set_text(asyncshell.demand('wscript -Kiev', 5):read("*l") or "Error")
+-- How to use:
+-- asyncshell.request('wscript -Kiev', function(output) wwidget.text = output end)
 
-local spawn = require('awful.util').spawn
+-- Grab environment
+local awful = require('awful')
 
-asyncshell               = {}
-asyncshell.request_table = {}
-asyncshell.id_counter    = 0
-asyncshell.folder        = "/tmp/asyncshell"
-asyncshell.file_template = asyncshell.folder .. '/req'
+-- Initialize tables for module
+local asyncshell = { request_table = {}, id_counter = 0 }
 
--- Create a directory for asynchell response files
-os.execute("mkdir -p " .. asyncshell.folder)
-
--- Returns next tag - unique identifier of the request
+-- Request counter
 local function next_id()
-   asyncshell.id_counter = (asyncshell.id_counter + 1) % 100000
-   return asyncshell.id_counter
+    asyncshell.id_counter = (asyncshell.id_counter + 1) % 10000
+    return asyncshell.id_counter
 end
 
--- Sends an asynchronous request for an output of the shell command.
+-- Remove given request
+function asyncshell.clear(id)
+    if asyncshell.request_table[id] then
+        if asyncshell.request_table[id].timer then
+            asyncshell.request_table[id].timer:stop()
+            asyncshell.request_table[id].timer = nil
+        end
+        asyncshell.request_table[id] = nil
+    end
+end
+
+-- Sends an asynchronous request for an output of the shell command
 -- @param command Command to be executed and taken output from
 -- @param callback Function to be called when the command finishes
--- @return Request ID
-function asyncshell.request(command, callback)
-   local id = next_id()
-   local tmpfname = asyncshell.file_template .. id
-   asyncshell.request_table[id] = { callback = callback }
-   local req =
-      string.format("sh -c '%s > %s; " ..
-                    'echo "asyncshell.deliver(%s)" | ' ..
-                    "awesome-client' 2> /dev/null",
-                    string.gsub(command, "'", "'\\''"), tmpfname, id)
-   spawn(req, false)
-   return id
+-- @param timeout Maximum amount of time to wait for the result (optional)
+function asyncshell.request(command, callback, timeout)
+    local id = next_id()
+    asyncshell.request_table[id] = { callback = callback }
+
+    local formatted_command = string.gsub(command, '"','\"')
+                              .. " | sed -e 's/\"/\\\\\"/g' -e ':a;N;$!ba;s/\\n/\\\\n/g'"
+
+    local req = string.format(
+        "echo \"asyncshell.deliver(%s, \\\"$(%s)\\\")\" | awesome-client &",
+        id, formatted_command
+    )
+
+    awful.util.spawn_with_shell(req)
+
+    if timeout then
+        asyncshell.request_table[id].timer = timer({ timeout = timeout })
+        asyncshell.request_table[id].timer:connect_signal("timeout", function() asyncshell.clear(id) end)
+        asyncshell.request_table[id].timer:start()
+    end
 end
 
--- Calls the remembered callback function on the output of the shell
--- command.
+-- Calls the remembered callback function on the output of the shell command
 -- @param id Request ID
--- @param output The output file of the shell command to be delievered
-function asyncshell.deliver(id)
-   if asyncshell.request_table[id] and
-      asyncshell.request_table[id].callback then
-      local output = io.open(asyncshell.file_template .. id, 'r')
-      asyncshell.request_table[id].callback(output)
-   end
-end
-
--- Sends a synchronous request for an output of the command. Waits for
--- the output, but if the given timeout expires returns nil.
--- @param command Command to be executed and taken output from
--- @param timeout Maximum amount of time to wait for the result
--- @return File handler on success, nil otherwise
-function asyncshell.demand(command, timeout)
-   local id = next_id()
-   local tmpfname = asyncshell.file_template .. id
-   local f = io.popen(string.format("(%s > %s; echo asyncshell_done) & " ..
-                                    "(sleep %s; echo asynchell_timeout)",
-                                    command, tmpfname, timeout))
-   local result = f:read("*line")
-   if result == "asyncshell_done" then
-      return io.open(tmpfname)
-   end
+-- @param output Shell command output to be delievered
+function asyncshell.deliver(id, output)
+    if asyncshell.request_table[id] then
+        asyncshell.request_table[id].callback(output)
+        asyncshell.clear(id)
+    end
 end
 
 return asyncshell

--- a/init.lua
+++ b/init.lua
@@ -10,6 +10,7 @@
 --]]
 
 package.loaded.lain = nil
+asyncshell = require("lain.asyncshell")
 
 local lain =
 {

--- a/widgets/abase.lua
+++ b/widgets/abase.lua
@@ -26,9 +26,8 @@ local function worker(args)
     abase.widget = wibox.widget.textbox('')
 
     function abase.update()
-        async.request(cmd, function(f)
-            output = f:read("*a")
-            f:close()
+        async.request(cmd, function(shell_output)
+            output = shell_output
             widget = abase.widget
             settings()
         end)

--- a/widgets/contrib/moc.lua
+++ b/widgets/contrib/moc.lua
@@ -47,7 +47,7 @@ local function worker(args)
         -- Artist: Travis
         -- Album: The Man Who
         -- etc.
-        async.request("mocp -i", function(f)
+        async.request("mocp -i", function(shell_output)
             moc_now = {
                 state   = "N/A",
                 file    = "N/A",
@@ -58,7 +58,7 @@ local function worker(args)
                 total   = "N/A"
             }
 
-            for line in f:lines() do
+            for line in string.gmatch(shell_output, "[^\n]+") do
                 for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
                     if k == "State" then moc_now.state = v
                     elseif k == "File" then moc_now.file = v

--- a/widgets/imap.lua
+++ b/widgets/imap.lua
@@ -57,9 +57,8 @@ local function worker(args)
         curl = string.format("%s --url imaps://%s:%s/INBOX -u %s:%q %s -k",
                head_command, server, port, mail, password, request)
 
-        async.request(curl, function(f)
-            ws = f:read("*a")
-            f:close()
+        async.request(curl, function(shell_output)
+            ws = shell_output
 
             _, mailcount = string.gsub(ws, "%d+", "")
             _ = nil

--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -52,7 +52,7 @@ local function worker(args)
     helpers.set_map("current mpd track", nil)
 
     function mpd.update()
-        async.request(echo .. " | curl --connect-timeout 1 -fsm 3 " .. mpdh, function (f)
+        async.request(echo .. " | curl --connect-timeout 1 -fsm 3 " .. mpdh, function (shell_output)
             mpd_now = {
                 state   = "N/A",
                 file    = "N/A",
@@ -64,7 +64,7 @@ local function worker(args)
                 elapsed = "N/A"
             }
 
-            for line in f:lines() do
+            for line in string.gmatch(shell_output, "[^\n]+") do
                 for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
                     if     k == "state"   then mpd_now.state   = v
                     elseif k == "file"    then mpd_now.file    = v


### PR DESCRIPTION
Asyncshell now works without saving data on disk.
Demand function removed.
Optional argument 'timeout' added to prevent outdated results.
Fixes #120
