### PR TITLE
only update widget text if it has changed since the last timer tick

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -76,7 +76,6 @@ end
 
 helpers.timer_table = {}
 
---function helpers.newtimer(_name, timeout, fun, nostart)
 function helpers.newtimer(_name, timeout, fun, nostart)
     local name = timeout
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -76,10 +76,17 @@ end
 
 helpers.timer_table = {}
 
-function helpers.newtimer(name, timeout, fun, nostart)
-    helpers.timer_table[name] = capi.timer({ timeout = timeout })
+--function helpers.newtimer(_name, timeout, fun, nostart)
+function helpers.newtimer(_name, timeout, fun, nostart)
+    local name = timeout
+
+    if not helpers.timer_table[name] then
+        helpers.timer_table[name] = capi.timer({ timeout = timeout })
+        helpers.timer_table[name]:start()
+    end
+
     helpers.timer_table[name]:connect_signal("timeout", fun)
-    helpers.timer_table[name]:start()
+
     if not nostart then
         helpers.timer_table[name]:emit_signal("timeout")
     end

--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -21,7 +21,12 @@ local setmetatable = setmetatable
 
 -- Battery infos
 -- lain.widgets.bat
-local bat = {}
+local bat = {
+    last_status = 0,
+    last_perc   = 0,
+    last_time   = 0,
+    last_watt   = 0
+}
 
 local function worker(args)
     local args = args or {}
@@ -115,11 +120,21 @@ local function worker(args)
             else
                 bat_now.watt = "N/A"
             end
-
         end
 
-        widget = bat.widget
-        settings()
+        if bat.last_status ~= bat_now.status
+        or bat.last_perc   ~= bat_now_perc
+        or bat.last_watt   ~= bat_now_watt
+        or bat.last_time   ~= bat_now_time
+        then
+            widget = bat.widget
+            settings()
+
+            bat.last_status = bat_now.status
+            bat.last_perc   = bat_now_perc
+            bat.last_watt   = bat_now_watt
+            bat.last_time   = bat_now_time
+        end
 
         -- notifications for low and critical states
         if bat_now.status == "Discharging" and notify == "on" and bat_now.perc ~= nil

--- a/widgets/cpu.lua
+++ b/widgets/cpu.lua
@@ -54,19 +54,21 @@ local function worker(args)
         end
         local active = total - idle
 
-        -- Read current data and calculate relative values.
-        local dactive = active - cpu.last_active
-        local dtotal = total - cpu.last_total
+        if cpu.last_active ~= active or cpu.last_total ~= total then
+            -- Read current data and calculate relative values.
+            local dactive = active - cpu.last_active
+            local dtotal = total - cpu.last_total
 
-        cpu_now = {}
-        cpu_now.usage = tostring(math.ceil((dactive / dtotal) * 100))
+            cpu_now = {}
+            cpu_now.usage = tostring(math.ceil((dactive / dtotal) * 100))
 
-        widget = cpu.widget
-        settings()
+            widget = cpu.widget
+            settings()
 
-        -- Save current data for the next run.
-        cpu.last_active = active
-        cpu.last_total = total
+            -- Save current data for the next run.
+            cpu.last_active = active
+            cpu.last_total = total
+        end
     end
 
     newtimer("cpu", timeout, update)

--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -25,7 +25,9 @@ local setmetatable = setmetatable
 
 -- File system disk space usage
 -- lain.widgets.fs
-local fs = {}
+local fs = {
+    last_used = 0
+}
 local fs_notification  = nil
 
 function fs:hide()
@@ -92,8 +94,12 @@ local function worker(args)
         fs_now.size_mb   = tonumber(fs_info[partition .. " size_mb"]) or 0
         fs_now.size_gb   = tonumber(fs_info[partition .. " size_gb"]) or 0
 
-        widget = fs.widget
-        settings()
+        if fs.last_used ~= fs_now.used then
+            widget = fs.widget
+            settings()
+
+            fs.last_used      = fs_now.used
+        end
 
         if fs_now.used >= 99 and not helpers.get_map(partition)
         then

--- a/widgets/mem.lua
+++ b/widgets/mem.lua
@@ -19,7 +19,14 @@ local setmetatable    = setmetatable
 
 -- Memory usage (ignoring caches)
 -- lain.widgets.mem
-local mem = {}
+local mem = {
+    last_total = 0,
+    last_free  = 0,
+    last_buf   = 0,
+    last_cache = 0,
+    last_swap  = 0,
+    last_swapf = 0
+}
 
 local function worker(args)
     local args     = args or {}
@@ -44,11 +51,26 @@ local function worker(args)
             end
         end
 
-        mem_now.used = mem_now.total - (mem_now.free + mem_now.buf + mem_now.cache)
-        mem_now.swapused = mem_now.swap - mem_now.swapf
+        if mem_now.total ~= mem.last_total
+        or mem_now.free  ~= mem.last_free
+        or mem_now.buf   ~= mem.last_buf
+        or mem_now.cache ~= mem.last_cache
+        or mem_now.swap  ~= mem.last_swap
+        or mem_now.swapf ~= mem.last_swapf
+        then
+            mem_now.used = mem_now.total - (mem_now.free + mem_now.buf + mem_now.cache)
+            mem_now.swapused = mem_now.swap - mem_now.swapf
 
-        widget = mem.widget
-        settings()
+            widget = mem.widget
+            settings()
+
+            mem.last_total = mem_now.total
+            mem.last_free  = mem_now.free
+            mem.last_buf   = mem_now.buf
+            mem.last_cache = mem_now.cache
+            mem.last_swap  = mem_now.swap
+            mem.last_swapf = mem_now.swapf
+        end
     end
 
     newtimer("mem", timeout, update)

--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -61,16 +61,17 @@ local function worker(args)
             iface = net.get_device()
         end
 
-        net_now.carrier = helpers.first_line('/sys/class/net/' .. iface ..
-                                           '/carrier') or "0"
-        net_now.state = helpers.first_line('/sys/class/net/' .. iface ..
-                                           '/operstate') or "down"
         local now_t = helpers.first_line('/sys/class/net/' .. iface ..
                                            '/statistics/tx_bytes') or 0
         local now_r = helpers.first_line('/sys/class/net/' .. iface ..
                                            '/statistics/rx_bytes') or 0
 
         if now_t ~= net.last_t or now_r ~= net.last_r then
+            net_now.carrier = helpers.first_line('/sys/class/net/' .. iface ..
+                                           '/carrier') or "0"
+            net_now.state = helpers.first_line('/sys/class/net/' .. iface ..
+                                           '/operstate') or "down"
+
             net_now.sent = (now_t - net.last_t) / timeout / units
             net_now.sent = string.gsub(string.format('%.1f', net_now.sent), ",", ".")
 
@@ -104,7 +105,7 @@ local function worker(args)
         end
     end
 
-    helpers.newtimer(iface, timeout, update)
+    helpers.newtimer(iface, timeout, update, false)
     return net.widget
 end
 

--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -51,7 +51,10 @@ local function worker(args)
     helpers.set_map(iface, true)
 
     function update()
-        net_now = {}
+        net_now = {
+            sent     = "0.0",
+            received = "0.0"
+        }
 
         if iface == "" or string.match(iface, "network off")
         then
@@ -67,17 +70,19 @@ local function worker(args)
         local now_r = helpers.first_line('/sys/class/net/' .. iface ..
                                            '/statistics/rx_bytes') or 0
 
-        net_now.sent = (now_t - net.last_t) / timeout / units
-        net_now.sent = string.gsub(string.format('%.1f', net_now.sent), ",", ".")
+        if now_t ~= net.last_t or now_r ~= net.last_r then
+            net_now.sent = (now_t - net.last_t) / timeout / units
+            net_now.sent = string.gsub(string.format('%.1f', net_now.sent), ",", ".")
 
-        net_now.received = (now_r - net.last_r) / timeout / units
-        net_now.received = string.gsub(string.format('%.1f', net_now.received), ",", ".")
+            net_now.received = (now_r - net.last_r) / timeout / units
+            net_now.received = string.gsub(string.format('%.1f', net_now.received), ",", ".")
 
-        widget = net.widget
-        settings()
+            widget = net.widget
+            settings()
 
-        net.last_t = now_t
-        net.last_r = now_r
+            net.last_t = now_t
+            net.last_r = now_r
+        end
 
         if net_now.carrier ~= "1" and notify == "on"
         then

--- a/widgets/temp.lua
+++ b/widgets/temp.lua
@@ -17,7 +17,9 @@ local setmetatable = setmetatable
 
 -- coretemp
 -- lain.widgets.temp
-local temp = {}
+local temp = {
+    last_t = 0
+}
 
 local function worker(args)
     local args     = args or {}
@@ -37,8 +39,12 @@ local function worker(args)
             coretemp_now = "N/A"
         end
 
-        widget = temp.widget
-        settings()
+        if temp.last_t ~= coretemp_now then
+            widget = temp.widget
+            settings()
+
+            temp.last_t = coretemp_now
+        end
     end
 
     newtimer("coretemp", timeout, update)


### PR DESCRIPTION
I realized that widget.set_markup() is kinda bottleneck. On my atom netbook awesome has around 8% cpu load if idle, when i set the timer to 1 second for each of my widgets. 

this patch reduces cpu load to 4-5% while still maintaining high refresh rates. fine tuning the timers reduces the cpu load further (I set them to 1 for testing the patch).

pls note, I only changed the widgets i use, the others, I cannot really test. would be nice if at least the base widget could get enhanced the same way, but i failed to make a clean implementation. my Lua skills are rather poor.