### PR TITLE
Many sizing fixes

### DIFF
--- a/layout/cascade.lua
+++ b/layout/cascade.lua
@@ -28,15 +28,12 @@ function cascade.arrange(p)
     local global_border = tonumber(beautiful.global_border_width) or 0
     if global_border < 0 then global_border = 0 end
 
-    -- Themes border width requires an offset.
-    local bw = tonumber(beautiful.border_width) or 0
-
     -- Screen.
     local wa = p.workarea
     local cls = p.clients
 
-    wa.height = wa.height - ((global_border * 2) + (bw * 2))
-    wa.width = wa.width - ((global_border * 2) + (bw * 2))
+    wa.height = wa.height - (global_border * 2)
+    wa.width = wa.width - (global_border * 2)
     wa.x = wa.x + global_border
     wa.y = wa.y + global_border
 
@@ -70,8 +67,8 @@ function cascade.arrange(p)
 
         g.x = wa.x + (how_many - i) * cascade.offset_x
         g.y = wa.y + (i - 1) * cascade.offset_y
-        g.width = wa.width - current_offset_x
-        g.height = wa.height - current_offset_y
+        g.width = wa.width - current_offset_x - 2*c.border_width
+        g.height = wa.height - current_offset_y - 2*c.border_width
 
         c:geometry(g)
     end

--- a/layout/cascade.lua
+++ b/layout/cascade.lua
@@ -69,6 +69,8 @@ function cascade.arrange(p)
         g.y = wa.y + (i - 1) * cascade.offset_y
         g.width = wa.width - current_offset_x - 2*c.border_width
         g.height = wa.height - current_offset_y - 2*c.border_width
+        if g.width < 1 then g.width = 1 end
+        if g.height < 1 then g.height = 1 end
 
         c:geometry(g)
     end

--- a/layout/cascadetile.lua
+++ b/layout/cascadetile.lua
@@ -57,6 +57,8 @@ function cascadetile.arrange(p)
     -- Borders are factored in.
     wa.height = wa.height - (global_border * 2)
     wa.width = wa.width - (global_border * 2)
+    wa.x = wa.x + global_border
+    wa.y = wa.y + global_border
 
     -- Width of main column?
     local t = tag.selected(p.screen)
@@ -101,8 +103,8 @@ function cascadetile.arrange(p)
         local g = {}
         -- Subtracting the useless_gap width from the work area width here
         -- makes this mwfact calculation work the same as in uselesstile.
-        -- Explicitly rounding is necessary to prevent the rendered size of
-        -- slavewid from changing depending on whether we round up or down.
+        -- Rounding is necessary to prevent the rendered size of slavewid
+        -- from being 1 pixel off when the result is not an integer.
         local mainwid = math.floor((wa.width - useless_gap) * mwfact)
         local slavewid = wa.width - mainwid
 
@@ -121,8 +123,8 @@ function cascadetile.arrange(p)
         end
 
         g.height = wa.height - 2*c.border_width
-        g.x = wa.x + global_border
-        g.y = wa.y + global_border
+        g.x = wa.x
+        g.y = wa.y
         if useless_gap > 0
         then
             -- Reduce width once and move window to the right. Reduce
@@ -150,8 +152,8 @@ function cascadetile.arrange(p)
                 g = {}
                 g.width = slavewid - current_offset_x - 2*c.border_width
                 g.height = wa.height - current_offset_y - 2*c.border_width
-                g.x = wa.x + mainwid + (how_many - (i - 1)) * cascadetile.offset_x + global_border
-                g.y = wa.y + (i - 2) * cascadetile.offset_y + global_border
+                g.x = wa.x + mainwid + (how_many - (i - 1)) * cascadetile.offset_x
+                g.y = wa.y + (i - 2) * cascadetile.offset_y
                 if useless_gap > 0
                 then
                     g.width = g.width - 2 * useless_gap

--- a/layout/cascadetile.lua
+++ b/layout/cascadetile.lua
@@ -152,8 +152,8 @@ function cascadetile.arrange(p)
                 c = cls[i]
                 g = {}
                 g.width = slavewid - current_offset_x - 2*bw
-                g.height = wa.height - current_offset_y -2*bw
-                g.x = wa.x + mainwid + (how_many - (i - 1)) * cascadetile.offset_x
+                g.height = wa.height - current_offset_y - 2*bw
+                g.x = wa.x + mainwid + (how_many - (i - 1)) * cascadetile.offset_x + global_border
                 g.y = wa.y + (i - 2) * cascadetile.offset_y + global_border
                 if useless_gap > 0
                 then

--- a/layout/cascadetile.lua
+++ b/layout/cascadetile.lua
@@ -141,6 +141,8 @@ function cascadetile.arrange(p)
                 g.width = g.width - useless_gap
             end
         end
+        if g.width < 1 then g.width = 1 end
+        if g.height < 1 then g.height = 1 end
         c:geometry(g)
 
         -- Remaining clients stacked in slave column, new ones on top.
@@ -161,6 +163,8 @@ function cascadetile.arrange(p)
                     g.x = g.x + useless_gap
                     g.y = g.y + useless_gap
                 end
+                if g.width < 1 then g.width = 1 end
+                if g.height < 1 then g.height = 1 end
                 c:geometry(g)
             end
         end

--- a/layout/cascadetile.lua
+++ b/layout/cascadetile.lua
@@ -100,7 +100,7 @@ function cascadetile.arrange(p)
     if #cls > 0
     then
         -- Main column, fixed width and height.
-        local c = cls[#cls]
+        local c = cls[1]
         local g = {}
         local mainwid = wa.width * mwfact
         local slavewid = wa.width - mainwid
@@ -143,14 +143,14 @@ function cascadetile.arrange(p)
         -- Remaining clients stacked in slave column, new ones on top.
         if #cls > 1
         then
-            for i = (#cls - 1),1,-1
+            for i = (#cls),2,-1
             do
                 c = cls[i]
                 g = {}
                 g.width = slavewid - current_offset_x
                 g.height = wa.height - current_offset_y
                 g.x = wa.x + mainwid + (how_many - i) * cascadetile.offset_x
-                g.y = wa.y + (i - 1) * cascadetile.offset_y + global_border
+                g.y = wa.y + (i - 2) * cascadetile.offset_y + global_border
                 if useless_gap > 0
                 then
                     g.width = g.width - 2 * useless_gap

--- a/layout/cascadetile.lua
+++ b/layout/cascadetile.lua
@@ -58,8 +58,8 @@ function cascadetile.arrange(p)
     local cls = p.clients
 
     -- Borders are factored in.
-    wa.height = wa.height - ((global_border * 2) + (bw * 2))
-    wa.width = wa.width - ((global_border * 2) + (bw * 2))
+    wa.height = wa.height - (global_border * 2)
+    wa.width = wa.width - (global_border * 2)
 
     -- Width of main column?
     local t = tag.selected(p.screen)
@@ -102,12 +102,16 @@ function cascadetile.arrange(p)
         -- Main column, fixed width and height.
         local c = cls[1]
         local g = {}
-        local mainwid = wa.width * mwfact
+        -- Subtracting the useless_gap width from the work area width here
+        -- makes this mwfact calculation work the same as in uselesstile.
+        -- Explicitly rounding is necessary to prevent the rendered size of
+        -- slavewid from changing depending on whether we round up or down.
+        local mainwid = math.floor((wa.width - useless_gap) * mwfact)
         local slavewid = wa.width - mainwid
 
         if overlap_main == 1
         then
-            g.width = wa.width
+            g.width = wa.width - 2*bw
 
             -- The size of the main window may be reduced a little bit.
             -- This allows you to see if there are any windows below the
@@ -116,10 +120,10 @@ function cascadetile.arrange(p)
             -- overlapping everything else.
             g.width = g.width - cascadetile.extra_padding
         else
-            g.width = mainwid
+            g.width = mainwid - 2*bw
         end
 
-        g.height = wa.height
+        g.height = wa.height - 2*bw
         g.x = wa.x + global_border
         g.y = wa.y + global_border
         if useless_gap > 0
@@ -143,13 +147,13 @@ function cascadetile.arrange(p)
         -- Remaining clients stacked in slave column, new ones on top.
         if #cls > 1
         then
-            for i = (#cls),2,-1
+            for i = 2,#cls
             do
                 c = cls[i]
                 g = {}
-                g.width = slavewid - current_offset_x
-                g.height = wa.height - current_offset_y
-                g.x = wa.x + mainwid + (how_many - i) * cascadetile.offset_x
+                g.width = slavewid - current_offset_x - 2*bw
+                g.height = wa.height - current_offset_y -2*bw
+                g.x = wa.x + mainwid + (how_many - (i - 1)) * cascadetile.offset_x
                 g.y = wa.y + (i - 2) * cascadetile.offset_y + global_border
                 if useless_gap > 0
                 then

--- a/layout/cascadetile.lua
+++ b/layout/cascadetile.lua
@@ -50,9 +50,6 @@ function cascadetile.arrange(p)
     local global_border = tonumber(beautiful.global_border_width) or 0
     if global_border < 0 then global_border = 0 end
 
-    -- Themes border width requires an offset
-    local bw = tonumber(beautiful.border_width) or 0
-
     -- Screen.
     local wa = p.workarea
     local cls = p.clients
@@ -111,7 +108,7 @@ function cascadetile.arrange(p)
 
         if overlap_main == 1
         then
-            g.width = wa.width - 2*bw
+            g.width = wa.width - 2*c.border_width
 
             -- The size of the main window may be reduced a little bit.
             -- This allows you to see if there are any windows below the
@@ -120,10 +117,10 @@ function cascadetile.arrange(p)
             -- overlapping everything else.
             g.width = g.width - cascadetile.extra_padding
         else
-            g.width = mainwid - 2*bw
+            g.width = mainwid - 2*c.border_width
         end
 
-        g.height = wa.height - 2*bw
+        g.height = wa.height - 2*c.border_width
         g.x = wa.x + global_border
         g.y = wa.y + global_border
         if useless_gap > 0
@@ -151,8 +148,8 @@ function cascadetile.arrange(p)
             do
                 c = cls[i]
                 g = {}
-                g.width = slavewid - current_offset_x - 2*bw
-                g.height = wa.height - current_offset_y - 2*bw
+                g.width = slavewid - current_offset_x - 2*c.border_width
+                g.height = wa.height - current_offset_y - 2*c.border_width
                 g.x = wa.x + mainwid + (how_many - (i - 1)) * cascadetile.offset_x + global_border
                 g.y = wa.y + (i - 2) * cascadetile.offset_y + global_border
                 if useless_gap > 0

--- a/layout/centerfair.lua
+++ b/layout/centerfair.lua
@@ -49,9 +49,6 @@ function centerfair.arrange(p)
     local global_border = tonumber(beautiful.global_border_width) or 0
     if global_border < 0 then global_border = 0 end
 
-    -- Themes border width requires an offset
-    local bw = tonumber(beautiful.border_width) or 0
-
     -- Screen.
     local wa = p.workarea
     local cls = p.clients
@@ -66,33 +63,35 @@ function centerfair.arrange(p)
     local ncol = centerfair.ncol or tag.getncol(t)
     if num_x <= 2 then num_x = 2 end
 
-    local width = math.floor((wa.width - (num_x + 1)*useless_gap - num_x*2*bw) / num_x)
+    local width = math.floor((wa.width - (num_x + 1)*useless_gap) / num_x)
 
     local offset_y = wa.y + useless_gap
     if #cls < num_x
     then
         -- Less clients than the number of columns, let's center it!
-        local offset_x = wa.x + (wa.width - #cls*width - #cls*2*bw - (#cls - 1)*useless_gap) / 2
+        local offset_x = wa.x + (wa.width - #cls*width - (#cls - 1)*useless_gap) / 2
         local g = {}
-        g.width = width
-        g.height = wa.height - 2*useless_gap - 2*bw
         g.y = offset_y + global_border
         for i = 1, #cls do
-            g.x = offset_x + (i - 1) * (width + useless_gap + 2*bw) + global_border
-            cls[i]:geometry(g)
+            local c = cls[i]
+            g.width = width - 2*c.border_width
+            g.height = wa.height - 2*useless_gap - 2*c.border_width
+            g.x = offset_x + (i - 1) * (width + useless_gap) + global_border
+            c:geometry(g)
         end
     else
         -- More clients than the number of columns, let's arrange it!
         local offset_x = wa.x + useless_gap
 
         -- Master client deserves a special treatement
+        local c = cls[1]
         local g = {}
-        g.width = wa.width - (num_x - 1)*width - (num_x + 1)*useless_gap - num_x*2*bw
-        g.height = wa.height - 2*useless_gap - 2*bw
+        g.width = wa.width - (num_x - 1)*width - (num_x + 1)*useless_gap - 2*c.border_width
+        g.height = wa.height - 2*useless_gap - 2*c.border_width
         g.x = offset_x + global_border
         g.y = offset_y + global_border
 
-        cls[1]:geometry(g)
+        c:geometry(g)
 
         -- Treat the other clients
 
@@ -132,21 +131,25 @@ function centerfair.arrange(p)
 
         -- Compute geometry of the other clients
         local nclient = 2 -- we start with the 2nd client
-        g.x = g.x + g.width + useless_gap + 2*bw
-        g.width = width
+        g.x = g.x + g.width + useless_gap + 2*c.border_width
 
         for i = 1, (num_x-1) do
-            g.height = math.floor((wa.height - (num_y[i] + 1)*useless_gap - num_y[i]*2*bw) / num_y[i])
+            local height = math.floor((wa.height - (num_y[i] + 1)*useless_gap) / num_y[i])
             g.y = offset_y + global_border
             for j = 0, (num_y[i]-2) do
-                cls[nclient]:geometry(g)
+                local c = cls[nclient]
+                g.height = height - 2*c.border_width
+                g.width = width - 2*c.border_width
+                c:geometry(g)
                 nclient = nclient + 1
-                g.y = g.y + g.height + useless_gap + 2*bw
+                g.y = g.y + height + useless_gap
             end
-            g.height = wa.height - (num_y[i] + 1)*useless_gap - (num_y[i] - 1)*g.height - num_y[i]*2*bw
-            cls[nclient]:geometry(g)
+            local c = cls[nclient]
+            g.height = wa.height - (num_y[i] + 1)*useless_gap - (num_y[i] - 1)*height - 2*c.border_width
+            g.width = width - 2*c.border_width
+            c:geometry(g)
             nclient = nclient + 1
-            g.x = g.x + g.width + useless_gap + 2*bw
+            g.x = g.x + width + useless_gap
         end
     end
 end

--- a/layout/centerfair.lua
+++ b/layout/centerfair.lua
@@ -77,6 +77,8 @@ function centerfair.arrange(p)
             local c = cls[i]
             g.width = width - 2*c.border_width
             g.height = wa.height - 2*useless_gap - 2*c.border_width
+            if g.width < 1 then g.width = 1 end
+            if g.height < 1 then g.height = 1 end
             g.x = offset_x + (i - 1) * (width + useless_gap)
             c:geometry(g)
         end
@@ -87,6 +89,8 @@ function centerfair.arrange(p)
         local g = {}
         g.width = wa.width - (num_x - 1)*width - (num_x + 1)*useless_gap - 2*c.border_width
         g.height = wa.height - 2*useless_gap - 2*c.border_width
+        if g.width < 1 then g.width = 1 end
+        if g.height < 1 then g.height = 1 end
         g.x = wa.x + useless_gap
         g.y = wa.y + useless_gap
 
@@ -139,6 +143,8 @@ function centerfair.arrange(p)
                 local c = cls[nclient]
                 g.height = height - 2*c.border_width
                 g.width = width - 2*c.border_width
+                if g.width < 1 then g.width = 1 end
+                if g.height < 1 then g.height = 1 end
                 c:geometry(g)
                 nclient = nclient + 1
                 g.y = g.y + height + useless_gap
@@ -146,6 +152,8 @@ function centerfair.arrange(p)
             local c = cls[nclient]
             g.height = wa.height - (num_y[i] + 1)*useless_gap - (num_y[i] - 1)*height - 2*c.border_width
             g.width = width - 2*c.border_width
+            if g.width < 1 then g.width = 1 end
+            if g.height < 1 then g.height = 1 end
             c:geometry(g)
             nclient = nclient + 1
             g.x = g.x + width + useless_gap

--- a/layout/centerfair.lua
+++ b/layout/centerfair.lua
@@ -83,16 +83,13 @@ function centerfair.arrange(p)
         end
     else
         -- More clients than the number of columns, let's arrange it!
-        local offset_x = wa.x
-        if useless_gap > 0 then
-           offset_x = offset_x
-        end
+        local offset_x = wa.x + useless_gap
 
         -- Master client deserves a special treatement
         local g = {}
-        g.width = wa.width - ((num_x - 1)*width + (num_x + 1)*useless_gap + num_x*2*bw)
+        g.width = wa.width - (num_x - 1)*width - (num_x + 1)*useless_gap - num_x*2*bw
         g.height = wa.height - 2*useless_gap - 2*bw
-        g.x = offset_x + useless_gap + global_border
+        g.x = offset_x + global_border
         g.y = offset_y + global_border
 
         cls[1]:geometry(g)
@@ -135,7 +132,7 @@ function centerfair.arrange(p)
 
         -- Compute geometry of the other clients
         local nclient = 2 -- we start with the 2nd client
-        g.x = g.x + g.width + 2*bw + useless_gap
+        g.x = g.x + g.width + useless_gap + 2*bw
         g.width = width
 
         for i = 1, (num_x-1) do
@@ -144,12 +141,12 @@ function centerfair.arrange(p)
             for j = 0, (num_y[i]-2) do
                 cls[nclient]:geometry(g)
                 nclient = nclient + 1
-                g.y = g.y + g.height + 2*bw + useless_gap
+                g.y = g.y + g.height + useless_gap + 2*bw
             end
-            g.height = wa.height - (num_y[i] + 1)*useless_gap - (num_y[i]-1)*g.height - num_y[i]*2*bw
+            g.height = wa.height - (num_y[i] + 1)*useless_gap - (num_y[i] - 1)*g.height - num_y[i]*2*bw
             cls[nclient]:geometry(g)
             nclient = nclient + 1
-            g.x = g.x + g.width + 2*bw + useless_gap
+            g.x = g.x + g.width + useless_gap + 2*bw
         end
     end
 end

--- a/layout/centerfair.lua
+++ b/layout/centerfair.lua
@@ -57,8 +57,8 @@ function centerfair.arrange(p)
     local cls = p.clients
 
     -- Borders are factored in.
-    wa.height = wa.height - ((global_border * 2) + (bw * 2))
-    wa.width = wa.width - ((global_border * 2) + (bw * 2))
+    wa.height = wa.height - (global_border * 2)
+    wa.width = wa.width - (global_border * 2)
 
     -- How many vertical columns? Read from nmaster on the tag.
     local t = tag.selected(p.screen)
@@ -66,19 +66,19 @@ function centerfair.arrange(p)
     local ncol = centerfair.ncol or tag.getncol(t)
     if num_x <= 2 then num_x = 2 end
 
-    local width = math.floor((wa.width-(num_x+1)*useless_gap) / num_x)
+    local width = math.floor((wa.width - (num_x + 1)*useless_gap - num_x*2*bw) / num_x)
 
     local offset_y = wa.y + useless_gap
     if #cls < num_x
     then
         -- Less clients than the number of columns, let's center it!
-        local offset_x = wa.x + useless_gap + (wa.width - #cls*width - (#cls+1)*useless_gap) / 2
+        local offset_x = wa.x + (wa.width - #cls*width - #cls*2*bw - (#cls - 1)*useless_gap) / 2
         local g = {}
         g.width = width
-        g.height = wa.height - 2*useless_gap - 2
+        g.height = wa.height - 2*useless_gap - 2*bw
         g.y = offset_y + global_border
         for i = 1, #cls do
-            g.x = offset_x + (#cls - i) * (width + useless_gap + 2) + global_border
+            g.x = offset_x + (i - 1) * (width + useless_gap + 2*bw) + global_border
             cls[i]:geometry(g)
         end
     else
@@ -90,12 +90,12 @@ function centerfair.arrange(p)
 
         -- Master client deserves a special treatement
         local g = {}
-        g.width = wa.width - (num_x  - 1) * width - num_x * 2*useless_gap - 2
-        g.height = wa.height - 2*useless_gap - 2
+        g.width = wa.width - ((num_x - 1)*width + (num_x + 1)*useless_gap + num_x*2*bw)
+        g.height = wa.height - 2*useless_gap - 2*bw
         g.x = offset_x + useless_gap + global_border
         g.y = offset_y + global_border
 
-        cls[#cls]:geometry(g)
+        cls[1]:geometry(g)
 
         -- Treat the other clients
 
@@ -134,28 +134,22 @@ function centerfair.arrange(p)
         end
 
         -- Compute geometry of the other clients
-        local nclient = #cls-1 -- we start with the 2nd client
-        g.x = g.x + g.width+useless_gap + 2
+        local nclient = 2 -- we start with the 2nd client
+        g.x = g.x + g.width + 2*bw + useless_gap
         g.width = width
 
-        if useless_gap > 0 then
-            g.width = g.width + useless_gap - 2
-        end
-
         for i = 1, (num_x-1) do
-            to_remove = 2
-            g.height = math.floor((wa.height - (num_y[i] * useless_gap)) / num_y[i])
+            g.height = math.floor((wa.height - (num_y[i] + 1)*useless_gap - num_y[i]*2*bw) / num_y[i])
             g.y = offset_y + global_border
             for j = 0, (num_y[i]-2) do
                 cls[nclient]:geometry(g)
-                nclient = nclient - 1
-                g.y = g.y + g.height+useless_gap + 2
-                to_remove = to_remove + 2
+                nclient = nclient + 1
+                g.y = g.y + g.height + 2*bw + useless_gap
             end
-            g.height = wa.height - num_y[i]*useless_gap - (num_y[i]-1)*g.height - useless_gap - to_remove
+            g.height = wa.height - (num_y[i] + 1)*useless_gap - (num_y[i]-1)*g.height - num_y[i]*2*bw
             cls[nclient]:geometry(g)
-            nclient = nclient - 1
-            g.x = g.x+g.width+useless_gap + 2
+            nclient = nclient + 1
+            g.x = g.x + g.width + 2*bw + useless_gap
         end
     end
 end

--- a/layout/centerfair.lua
+++ b/layout/centerfair.lua
@@ -56,6 +56,8 @@ function centerfair.arrange(p)
     -- Borders are factored in.
     wa.height = wa.height - (global_border * 2)
     wa.width = wa.width - (global_border * 2)
+    wa.x = wa.x + global_border
+    wa.y = wa.y + global_border
 
     -- How many vertical columns? Read from nmaster on the tag.
     local t = tag.selected(p.screen)
@@ -65,31 +67,28 @@ function centerfair.arrange(p)
 
     local width = math.floor((wa.width - (num_x + 1)*useless_gap) / num_x)
 
-    local offset_y = wa.y + useless_gap
     if #cls < num_x
     then
         -- Less clients than the number of columns, let's center it!
         local offset_x = wa.x + (wa.width - #cls*width - (#cls - 1)*useless_gap) / 2
         local g = {}
-        g.y = offset_y + global_border
+        g.y = wa.y + useless_gap
         for i = 1, #cls do
             local c = cls[i]
             g.width = width - 2*c.border_width
             g.height = wa.height - 2*useless_gap - 2*c.border_width
-            g.x = offset_x + (i - 1) * (width + useless_gap) + global_border
+            g.x = offset_x + (i - 1) * (width + useless_gap)
             c:geometry(g)
         end
     else
         -- More clients than the number of columns, let's arrange it!
-        local offset_x = wa.x + useless_gap
-
         -- Master client deserves a special treatement
         local c = cls[1]
         local g = {}
         g.width = wa.width - (num_x - 1)*width - (num_x + 1)*useless_gap - 2*c.border_width
         g.height = wa.height - 2*useless_gap - 2*c.border_width
-        g.x = offset_x + global_border
-        g.y = offset_y + global_border
+        g.x = wa.x + useless_gap
+        g.y = wa.y + useless_gap
 
         c:geometry(g)
 
@@ -135,7 +134,7 @@ function centerfair.arrange(p)
 
         for i = 1, (num_x-1) do
             local height = math.floor((wa.height - (num_y[i] + 1)*useless_gap) / num_y[i])
-            g.y = offset_y + global_border
+            g.y = wa.y + useless_gap
             for j = 0, (num_y[i]-2) do
                 local c = cls[nclient]
                 g.height = height - 2*c.border_width

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -60,6 +60,8 @@ function centerwork.arrange(p)
 
         g.height = wa.height - 2*useless_gap - 2*c.border_width
         g.width = mainwid - 2*c.border_width
+        if g.width < 1 then g.width = 1 end
+        if g.height < 1 then g.height = 1 end
         g.x = wa.x + slaveLwid
         g.y = wa.y + useless_gap
 
@@ -112,6 +114,8 @@ function centerwork.arrange(p)
                     g.height = slaveBhei - 2*useless_gap - 2*c.border_width
                 end
 
+                if g.width < 1 then g.width = 1 end
+                if g.height < 1 then g.height = 1 end
                 c:geometry(g)
 
                 at = at + 1

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -32,9 +32,6 @@ function centerwork.arrange(p)
     local global_border = tonumber(beautiful.global_border_width) or 0
     if global_border < 0 then global_border = 0 end
 
-    -- Themes border width requires an offset
-    local bw = tonumber(beautiful.border_width) or 0
-
     -- Screen.
     local wa = p.workarea
     local cls = p.clients
@@ -59,8 +56,8 @@ function centerwork.arrange(p)
         local slaveThei = math.floor(wa.height / 2)
         local slaveBhei = wa.height - slaveThei
 
-        g.height = wa.height - 2*useless_gap - 2*bw
-        g.width = mainwid - 2*bw
+        g.height = wa.height - 2*useless_gap - 2*c.border_width
+        g.width = mainwid - 2*c.border_width
         g.x = wa.x + slaveLwid + global_border
         g.y = wa.y + useless_gap + global_border
 
@@ -88,29 +85,29 @@ function centerwork.arrange(p)
                     -- top left
                     g.x = wa.x + useless_gap + global_border
                     g.y = wa.y + useless_gap + global_border
-                    g.width = slaveLwid - 2*useless_gap - 2*bw
-                    g.height = slaveThei - useless_gap - 2*bw
+                    g.width = slaveLwid - 2*useless_gap - 2*c.border_width
+                    g.height = slaveThei - useless_gap - 2*c.border_width
                 elseif i - 2 == centerwork.top_right
                 then
                     -- top right
                     g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
                     g.y = wa.y + useless_gap + global_border
-                    g.width = slaveRwid - 2*useless_gap - 2*bw
-                    g.height = slaveThei - useless_gap - 2*bw
+                    g.width = slaveRwid - 2*useless_gap - 2*c.border_width
+                    g.height = slaveThei - useless_gap - 2*c.border_width
                 elseif i - 2 == centerwork.bottom_left
                 then
                     -- bottom left
                     g.x = wa.x + useless_gap + global_border
                     g.y = wa.y + slaveThei + useless_gap + global_border
-                    g.width = slaveLwid - 2*useless_gap - 2*bw
-                    g.height = slaveBhei - 2*useless_gap - 2*bw
+                    g.width = slaveLwid - 2*useless_gap - 2*c.border_width
+                    g.height = slaveBhei - 2*useless_gap - 2*c.border_width
                 elseif i - 2 == centerwork.bottom_right
                 then
                     -- bottom right
                     g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
                     g.y = wa.y + slaveThei + useless_gap + global_border
-                    g.width = slaveRwid - 2*useless_gap - 2*bw
-                    g.height = slaveBhei - 2*useless_gap - 2*bw
+                    g.width = slaveRwid - 2*useless_gap - 2*c.border_width
+                    g.height = slaveBhei - 2*useless_gap - 2*c.border_width
                 end
 
                 c:geometry(g)

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -40,8 +40,8 @@ function centerwork.arrange(p)
     local cls = p.clients
 
     -- Borders are factored in.
-    wa.height = wa.height - ((global_border * 2) + (bw * 2))
-    wa.width = wa.width - ((global_border * 2) + (bw * 2))
+    wa.height = wa.height - (global_border * 2)
+    wa.width = wa.width - (global_border * 2)
 
     -- Width of main column?
     local t = awful.tag.selected(p.screen)
@@ -59,8 +59,8 @@ function centerwork.arrange(p)
         local slaveThei = math.floor(wa.height / 2)
         local slaveBhei = wa.height - slaveThei
 
-        g.height = wa.height - 2 * useless_gap
-        g.width = mainwid
+        g.height = wa.height - 2*useless_gap - 2*bw
+        g.width = mainwid - 2*bw
         g.x = wa.x + slaveLwid + global_border
         g.y = wa.y + useless_gap + global_border
 
@@ -70,7 +70,7 @@ function centerwork.arrange(p)
         if #cls > 1
         then
             local at = 0
-            for i = (#cls),2,-1
+            for i = 2,#cls
             do
                 -- It's all fixed. If there are more than 5 clients,
                 -- those additional clients will float. This is
@@ -88,29 +88,29 @@ function centerwork.arrange(p)
                     -- top left
                     g.x = wa.x + useless_gap + global_border
                     g.y = wa.y + useless_gap + global_border
-                    g.width = slaveLwid - 2 * useless_gap
-                    g.height = slaveThei - useless_gap
+                    g.width = slaveLwid - 2*useless_gap - 2*bw
+                    g.height = slaveThei - useless_gap - 2*bw
                 elseif i - 2 == centerwork.top_right
                 then
                     -- top right
                     g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
                     g.y = wa.y + useless_gap + global_border
-                    g.width = slaveRwid - 2 * useless_gap
-                    g.height = slaveThei - useless_gap
+                    g.width = slaveRwid - 2*useless_gap - 2*bw
+                    g.height = slaveThei - useless_gap - 2*bw
                 elseif i - 2 == centerwork.bottom_left
                 then
                     -- bottom left
                     g.x = wa.x + useless_gap + global_border
                     g.y = wa.y + slaveThei + useless_gap + global_border
-                    g.width = slaveLwid - 2 * useless_gap
-                    g.height = slaveBhei - 2 * useless_gap
+                    g.width = slaveLwid - 2*useless_gap - 2*bw
+                    g.height = slaveBhei - 2*useless_gap - 2*bw
                 elseif i - 2 == centerwork.bottom_right
                 then
                     -- bottom right
                     g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
                     g.y = wa.y + slaveThei + useless_gap + global_border
-                    g.width = slaveRwid - 2 * useless_gap
-                    g.height = slaveBhei - 2 * useless_gap
+                    g.width = slaveRwid - 2*useless_gap - 2*bw
+                    g.height = slaveBhei - 2*useless_gap - 2*bw
                 end
 
                 c:geometry(g)

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -39,6 +39,8 @@ function centerwork.arrange(p)
     -- Borders are factored in.
     wa.height = wa.height - (global_border * 2)
     wa.width = wa.width - (global_border * 2)
+    wa.x = wa.x + global_border
+    wa.y = wa.y + global_border
 
     -- Width of main column?
     local t = awful.tag.selected(p.screen)
@@ -58,8 +60,8 @@ function centerwork.arrange(p)
 
         g.height = wa.height - 2*useless_gap - 2*c.border_width
         g.width = mainwid - 2*c.border_width
-        g.x = wa.x + slaveLwid + global_border
-        g.y = wa.y + useless_gap + global_border
+        g.x = wa.x + slaveLwid
+        g.y = wa.y + useless_gap
 
         c:geometry(g)
 
@@ -83,29 +85,29 @@ function centerwork.arrange(p)
                 if i - 2 == centerwork.top_left
                 then
                     -- top left
-                    g.x = wa.x + useless_gap + global_border
-                    g.y = wa.y + useless_gap + global_border
+                    g.x = wa.x + useless_gap
+                    g.y = wa.y + useless_gap
                     g.width = slaveLwid - 2*useless_gap - 2*c.border_width
                     g.height = slaveThei - useless_gap - 2*c.border_width
                 elseif i - 2 == centerwork.top_right
                 then
                     -- top right
-                    g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
-                    g.y = wa.y + useless_gap + global_border
+                    g.x = wa.x + slaveLwid + mainwid + useless_gap
+                    g.y = wa.y + useless_gap
                     g.width = slaveRwid - 2*useless_gap - 2*c.border_width
                     g.height = slaveThei - useless_gap - 2*c.border_width
                 elseif i - 2 == centerwork.bottom_left
                 then
                     -- bottom left
-                    g.x = wa.x + useless_gap + global_border
-                    g.y = wa.y + slaveThei + useless_gap + global_border
+                    g.x = wa.x + useless_gap
+                    g.y = wa.y + slaveThei + useless_gap
                     g.width = slaveLwid - 2*useless_gap - 2*c.border_width
                     g.height = slaveBhei - 2*useless_gap - 2*c.border_width
                 elseif i - 2 == centerwork.bottom_right
                 then
                     -- bottom right
-                    g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
-                    g.y = wa.y + slaveThei + useless_gap + global_border
+                    g.x = wa.x + slaveLwid + mainwid + useless_gap
+                    g.y = wa.y + slaveThei + useless_gap
                     g.width = slaveRwid - 2*useless_gap - 2*c.border_width
                     g.height = slaveBhei - 2*useless_gap - 2*c.border_width
                 end

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -18,8 +18,8 @@ local centerwork =
     name         = "centerwork",
     top_left     = 0,
     top_right    = 1,
-    bottom_left  = 2,
-    bottom_right = 3
+    bottom_left  = 3,
+    bottom_right = 2
 }
 
 function centerwork.arrange(p)
@@ -50,7 +50,7 @@ function centerwork.arrange(p)
     if #cls > 0
     then
         -- Main column, fixed width and height.
-        local c = cls[#cls]
+        local c = cls[1]
         local g = {}
         local mainwid = math.floor(wa.width * mwfact)
         local slavewid = wa.width - mainwid
@@ -70,7 +70,7 @@ function centerwork.arrange(p)
         if #cls > 1
         then
             local at = 0
-            for i = (#cls - 1),1,-1
+            for i = (#cls),2,-1
             do
                 -- It's all fixed. If there are more than 5 clients,
                 -- those additional clients will float. This is
@@ -83,28 +83,28 @@ function centerwork.arrange(p)
                 c = cls[i]
                 g = {}
 
-                if at == centerwork.top_left
+                if i - 2 == centerwork.top_left
                 then
                     -- top left
                     g.x = wa.x + useless_gap + global_border
                     g.y = wa.y + useless_gap + global_border
                     g.width = slaveLwid - 2 * useless_gap
                     g.height = slaveThei - useless_gap
-                elseif at == centerwork.top_right
+                elseif i - 2 == centerwork.top_right
                 then
                     -- top right
                     g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border
                     g.y = wa.y + useless_gap + global_border
                     g.width = slaveRwid - 2 * useless_gap
                     g.height = slaveThei - useless_gap
-                elseif at == centerwork.bottom_left
+                elseif i - 2 == centerwork.bottom_left
                 then
                     -- bottom left
                     g.x = wa.x + useless_gap + global_border
                     g.y = wa.y + slaveThei + useless_gap + global_border
                     g.width = slaveLwid - 2 * useless_gap
                     g.height = slaveBhei - 2 * useless_gap
-                elseif at == centerwork.bottom_right
+                elseif i - 2 == centerwork.bottom_right
                 then
                     -- bottom right
                     g.x = wa.x + slaveLwid + mainwid + useless_gap + global_border

--- a/layout/centerwork.lua
+++ b/layout/centerwork.lua
@@ -16,10 +16,10 @@ local math      = { floor = math.floor }
 local centerwork =
 {
     name         = "centerwork",
-    top_left     = 0,
-    top_right    = 1,
-    bottom_left  = 3,
-    bottom_right = 2
+    top_right    = 0,
+    bottom_right = 1,
+    bottom_left  = 2,
+    top_left     = 3
 }
 
 function centerwork.arrange(p)

--- a/layout/termfair.lua
+++ b/layout/termfair.lua
@@ -53,6 +53,8 @@ function termfair.arrange(p)
     -- Borders are factored in.
     wa.height = wa.height - (global_border * 2)
     wa.width = wa.width - (global_border * 2)
+    wa.x = wa.x + global_border
+    wa.y = wa.y + global_border
 
     -- How many vertical columns?
     local t = tag.selected(p.screen)
@@ -101,8 +103,8 @@ function termfair.arrange(p)
                 g.height = height - 2*c.border_width
             end
 
-            g.x = wa.x + this_x*width + global_border
-            g.y = wa.y + this_y*height + global_border
+            g.x = wa.x + this_x*width
+            g.y = wa.y + this_y*height
 
             if useless_gap > 0
             then

--- a/layout/termfair.lua
+++ b/layout/termfair.lua
@@ -46,16 +46,13 @@ function termfair.arrange(p)
     local global_border = tonumber(beautiful.global_border_width) or 0
     if global_border < 0 then global_border = 0 end
 
-    -- Themes border width requires an offset
-    local bw = tonumber(beautiful.border_width) or 0
-
     -- Screen.
     local wa = p.workarea
     local cls = p.clients
 
     -- Borders are factored in.
-    wa.height = wa.height - ((global_border * 2) + (bw * 2))
-    wa.width = wa.width - ((global_border * 2) + (bw * 2))
+    wa.height = wa.height - (global_border * 2)
+    wa.width = wa.width - (global_border * 2)
 
     -- How many vertical columns?
     local t = tag.selected(p.screen)
@@ -71,8 +68,8 @@ function termfair.arrange(p)
         local at_x = 0
         local at_y = 0
         local remaining_clients = #cls
-        local width = math.floor(wa.width / num_x)
-        local height = math.floor(wa.height / num_y)
+        local width = math.floor((wa.width - (num_x + 1)*useless_gap) / num_x)
+        local height = math.floor((wa.height - (num_y + 1)*useless_gap) / num_y)
 
         -- We start the first row. Left-align by limiting the number of
         -- available slots.
@@ -93,25 +90,25 @@ function termfair.arrange(p)
             local g = {}
             if this_x == (num_x - 1)
             then
-                g.width = wa.width - (num_x - 1) * width - useless_gap
+                g.width = wa.width - (num_x - 1)*width - (num_x + 1)*useless_gap - 2*c.border_width
             else
-                g.width = width - useless_gap
+                g.width = width - 2*c.border_width
             end
             if this_y == (num_y - 1)
             then
-                g.height = wa.height - (num_y - 1) * height - useless_gap
+                g.height = wa.height - (num_y - 1)*height - (num_y + 1)*useless_gap - 2*c.border_width
             else
-                g.height = height - useless_gap
+                g.height = height - 2*c.border_width
             end
 
-            g.x = wa.x + this_x * width + global_border
-            g.y = wa.y + this_y * height + global_border
+            g.x = wa.x + this_x*width + global_border
+            g.y = wa.y + this_y*height + global_border
 
             if useless_gap > 0
             then
                 -- All clients tile evenly.
-                g.x = g.x + (useless_gap / 2)
-                g.y = g.y + (useless_gap / 2)
+                g.x = g.x + (this_x + 1)*useless_gap
+                g.y = g.y + (this_y + 1)*useless_gap
 
             end
             c:geometry(g)

--- a/layout/termfair.lua
+++ b/layout/termfair.lua
@@ -113,6 +113,8 @@ function termfair.arrange(p)
                 g.y = g.y + (this_y + 1)*useless_gap
 
             end
+            if g.width < 1 then g.width = 1 end
+            if g.height < 1 then g.height = 1 end
             c:geometry(g)
             remaining_clients = remaining_clients - 1
 

--- a/layout/uselesstile.lua
+++ b/layout/uselesstile.lua
@@ -37,7 +37,7 @@ end
 
 -- Find geometry for secondary windows column
 local function cut_column(wa, n, index)
-    local width = wa.width / n
+    local width = math.floor(wa.width / n)
     local area = { x = wa.x + (index - 1) * width, y = wa.y, width = width, height = wa.height }
 
     return area
@@ -45,7 +45,7 @@ end
 
 -- Find geometry for certain window in column
 local function cut_row(wa, factor, index, used)
-    local height = wa.height * factor.window[index] / factor.total
+    local height = math.floor(wa.height * factor.window[index] / factor.total)
     local area = { x = wa.x, y = wa.y + used, width = wa.width, height = height }
 
     return area
@@ -55,8 +55,8 @@ end
 local function size_correction(c, geometry, useless_gap)
     geometry.width  = math.max(geometry.width  - 2 * c.border_width - useless_gap, 1)
     geometry.height = math.max(geometry.height - 2 * c.border_width - useless_gap, 1)
-    geometry.x = geometry.x + useless_gap / 2
-    geometry.y = geometry.y + useless_gap / 2
+    geometry.x = math.floor(geometry.x + useless_gap / 2)
+    geometry.y = math.floor(geometry.y + useless_gap / 2)
 end
 
 -- Check size factor for group of clients and calculate total
@@ -85,6 +85,7 @@ local function tile_column(canvas, area, list, useless_gap, transformation, winf
 
     for i, c in ipairs(list) do
         local g = cut_row(area, factor, i, used)
+        if i == #list then g.height = area.height - used end
         used = used + g.height
 
         -- swap workarea dimensions
@@ -93,6 +94,7 @@ local function tile_column(canvas, area, list, useless_gap, transformation, winf
 
         -- useless gap and border correction
         size_correction(c, g, useless_gap)
+
 
         c:geometry(g)
     end
@@ -161,7 +163,7 @@ local function tile(p, orientation)
     local master_area = {
         x = wa.x,
         y = wa.y,
-        width  = nmaster > 0 and wa.width * mwfact or 0,
+        width  = nmaster > 0 and math.floor(wa.width * mwfact) or 0,
         height = wa.height
     }
 

--- a/layout/uselesstile.lua
+++ b/layout/uselesstile.lua
@@ -188,6 +188,7 @@ local function tile(p, orientation)
     local rows_min = math.floor(#cls_other / ncol)
 
     local client_index = 1
+    local used = 0
     for i = 1, ncol do
         local position = transformation.flip and ncol - i + 1 or i
         local rows = i <= last_small_column and rows_min or rows_min + 1
@@ -200,6 +201,8 @@ local function tile(p, orientation)
 
         -- and tile
         local column_area = cut_column(other_area, ncol, position)
+        if i == ncol then column_area.width = other_area.width - used end
+        used = used + column_area.width
 
         if not data[i] then data[i] = {} end
         tile_column(wa, column_area, column, useless_gap, transformation, data[i])


### PR DESCRIPTION
All the layouts had some minor issues with sizing and spacing of the clients, so I fixed a bunch of them and added accounting for individual client borders. I haven't touched uselessfair or uselessspiral, so they may have some 1 pixel discrepancies still, and uselesstile has the potential for being 1 pixel off when there are multiple slave columns, but those are the only ones I know about.

You may want to leave out the part where I changed the arrangement of the auxiliary windows in centerwork and the parts where I switched from using cls[#cls] to cls[1] for the master window depending on your preferences, but all the sizing and spacing changes can be applied without those.