### PR TITLE
Added name attribute to mpd widget

### DIFF
--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -71,6 +71,7 @@ local function worker(args)
                 for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
                     if     k == "state"   then mpd_now.state   = v
                     elseif k == "file"    then mpd_now.file    = v
+                    elseif k == "Name"    then mpd_now.name    = escape_f(v)
                     elseif k == "Artist"  then mpd_now.artist  = escape_f(v)
                     elseif k == "Title"   then mpd_now.title   = escape_f(v)
                     elseif k == "Album"   then mpd_now.album   = escape_f(v)


### PR DESCRIPTION
Metadata from some extern sources (e.g. soundcloud) is not parsed properly to a ``title`` by mpd so the ``name`` attribute is set instead.
Helps to determine what is actually playing in ``settings()``.