### PR TITLE
Fixed unaccessible bat object in bat.lua.

### DIFF
--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -159,4 +159,4 @@ local function worker(args)
     return bat.widget
 end
 
-return setmetatable(bat, { __call = function(_, ...) return worker(...) end })
+return setmetatable({}, { __call = function(_, ...) return worker(...) end })


### PR DESCRIPTION
bat is local to worker, therefore cannot be accessed from outside.