### PR TITLE
Fix width of CPU usage

### DIFF
--- a/widgets/cpu.lua
+++ b/widgets/cpu.lua
@@ -59,7 +59,7 @@ local function worker(args)
         local dtotal = total - cpu.last_total
 
         cpu_now = {}
-        cpu_now.usage = tostring(math.ceil((dactive / dtotal) * 100))
+        cpu_now.usage = string.format("%2d", math.ceil((dactive / dtotal) * 100))
 
         widget = cpu.widget
         settings()


### PR DESCRIPTION
CPU usage is one of the indicators which are prone to go below/other 10% frequently. With the original version this means that the left part of the widgets bar shifts 1 character every time it crosses this limit, which I find to be visually annoying. The proposed modification reserves 2 spaces for display, so of the time the widget bar will not move (at least not because of CPU usage variation), unless it reaches 100% (which should be rare and would produce much more annoyance anyway).

Same may apply to network in/out flux indicator but it is more complicated to foresee what would be a reasonable trade-off between wasted space and stability, as it depends on expected fluxes. Moreover they are (by default) located on the left end of the bar, which minimizes the "shifting" effect.