### PR TITLE
helpers: spairs() added

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -13,6 +13,7 @@ local io     = { open  = io.open,
                  lines = io.lines,
                  popen = io.popen }
 local rawget = rawget
+local table  = { sort   = table.sort }
 
 -- Lain helper functions for internal use
 -- lain.helpers
@@ -112,5 +113,24 @@ function helpers.get_map(element)
 end
 
 -- }}}
+
+--{{{ Iterate over table of records sorted by keys
+function helpers.spairs(t)
+    -- collect the keys
+    local keys = {}
+    for k in pairs(t) do keys[#keys+1] = k end
+
+    table.sort(keys)
+
+    -- return the iterator function
+    local i = 0
+    return function()
+        i = i + 1
+        if keys[i] then
+            return keys[i], t[keys[i]]
+        end
+    end
+end
+--}}}
 
 return helpers

--- a/widgets/maildir.lua
+++ b/widgets/maildir.lua
@@ -9,6 +9,7 @@
 
 local newtimer        = require("lain.helpers").newtimer
 local read_pipe       = require("lain.helpers").read_pipe
+local spairs          = require("lain.helpers").spairs
 
 local wibox           = require("wibox")
 
@@ -19,7 +20,6 @@ local os              = { getenv = os.getenv }
 local pairs           = pairs
 local string          = { len    = string.len,
                           match  = string.match }
-local table           = { sort   = table.sort }
 
 local setmetatable    = setmetatable
 
@@ -65,14 +65,13 @@ local function worker(args)
             end
         until line == nil
 
-	p:close()
-        table.sort(boxes)
+        p:close()
 
         newmail = "no mail"
         -- Count the total number of mails irrespective of where it was found
         total = 0
 
-        for box, number in pairs(boxes)
+        for box, number in spairs(boxes)
         do
             -- Add this box only if it's not to be ignored.
             if not util.element_in_table(box, ignore_boxes)


### PR DESCRIPTION
Since we can't sort table of records directly, `table.sort(boxes)` in maildir.lua makes no sence, and we have to use a hack.