### PR TITLE
Add callback function for to update sink

### DIFF
--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -23,6 +23,7 @@ local function worker(args)
    local args        = args or {}
    local timeout     = args.timeout or 5
    local settings    = args.settings or function() end
+   local scallback   = args.scallback or function() end
 
    pulseaudio.sink   = args.sink or 0 -- user defined or first one
    pulseaudio.cmd    = args.cmd or string.format("pacmd list-sinks | sed -n -e '/base volume/d' -e '/index: %d/p' -e '/volume:/p' -e '/muted:/p' | sed -n -e '/index: %d/,+2p'",
@@ -36,6 +37,10 @@ local function worker(args)
       volume_now.left  = tonumber(string.match(s, "left.-(%d+)%%")) or tonumber(string.match(s, "0:.-(%d+)%%"))
       volume_now.right = tonumber(string.match(s, "right.-(%d+)%%")) or tonumber(string.match(s, "1:.-(%d+)%%"))
       volume_now.muted = string.match(s, "muted: (%S+)")
+
+      if scallback ~= nil then
+         pulseaudio.sink   = scallback()
+      end
 
       widget = pulseaudio.widget
       settings()

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -23,7 +23,7 @@ local function worker(args)
    local args        = args or {}
    local timeout     = args.timeout or 5
    local settings    = args.settings or function() end
-   local scallback   = args.scallback or function() end
+   local scallback   = args.scallback or nil
 
    pulseaudio.sink   = args.sink or 0 -- user defined or first one
    pulseaudio.cmd    = args.cmd or string.format("pacmd list-sinks | sed -n -e '/base volume/d' -e '/index: %d/p' -e '/volume:/p' -e '/muted:/p' | sed -n -e '/index: %d/,+2p'",


### PR DESCRIPTION
Hello!

I use your plugins! Thanks!

My system have two audio channel output(hdmi and analog output) and for this reason I must update the sink value of pulseauido plugin.

Please, review my changes.

This is example, how I use your plugin:
```lua
volpulse = lain.widgets.pulseaudio({cmd = "pacmd list-sinks | sed -n -e '/base volume/d' -e '/index: %d/p' -e '/volume:/p' -e '/muted:/p'",
                                    settings = function()
                                       if volume_now.muted == "yes" then
                                          volicon:set_image(beautiful.widget_no_vol)
                                       else
                                          volicon:set_image(beautiful.widget_vol)
                                       end

                                       widget:set_markup(markup("#7493d2", volume_now.left .. "% "))
                                    end,
                                    scallback = function()
                                       local s = awful.util.pread("pacmd list-sinks | grep index -A1| tr '*' ' ' | grep alsa_output -B1| grep index|sed 's/ //g'")
                                       return tonumber(string.match(s, "index:(%d+)"))
                                    end
                                   })
```
Thanks!


