### PR TITLE
Fixed initial state where alsa.update may never be called

### DIFF
--- a/widgets/alsa.lua
+++ b/widgets/alsa.lua
@@ -19,7 +19,7 @@ local setmetatable    = setmetatable
 
 -- ALSA volume
 -- lain.widgets.alsa
-local alsa = { last_level = "0", last_status = "off" }
+local alsa = { last_level = "0", last_status = "" }
 
 local function worker(args)
     local args     = args or {}


### PR DESCRIPTION
If the volume level is 0 and the state is off on startup, alsa.update never gets called and the widget doesn't render.