### PR TITLE
crash fix - sink value initialized

### DIFF
--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -27,6 +27,7 @@ local function worker(args)
 
    pulseaudio.cmd    = args.cmd or string.format("pacmd list-sinks | sed -n -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p'")
    pulseaudio.widget = wibox.widget.textbox('')
+   pulseaudio.sink = 'autodetected'
 
    function pulseaudio.update()
       if scallback then pulseaudio.cmd = scallback() end


### PR DESCRIPTION
Without particular input (no `scallback` or `settings` functions), `pulseaudio.sink` isn't defined and we can't use it in `string.format("pulseaudio-%s", pulseaudio.sink)` when timer is created (`newtimer` function).
Alternatively, we could remove `string.format` function and let sink value undefined.

I'm working on a better solution, but this fix should work and prevent crashing when `lain.widgets.pulseaudio()` is called in rc.lua without arguments.