### PR TITLE
Fix calendar highlighting by letting user handle it

### DIFF
--- a/widgets/calendar.lua
+++ b/widgets/calendar.lua
@@ -50,8 +50,8 @@ function calendar:show(t_out, inc_offset, scr)
         calendar.notify_icon = calendar.icons .. today .. ".png"
 
         -- bg and fg inverted to highlight today
-        f = io.popen(string.format("%s | sed -r -e 's/_\\x08//g' -e '0,/(^| )%d($| )/ s/(^| )%d($| )/\\1<b><span foreground=\"%s\" background=\"%s\">%d<\\/span><\\/b>\\2/'",
-                     calendar.cal, today, today, calendar.bg, calendar.fg, today))
+        f = io.popen(string.format("%s | sed -e 's|\x1b\\[7m|<span foreground=\"%s\" background=\"%s\">|g' -e 's|\x1b\\[27m|</span>|g'",
+                     calendar.cal, calendar.bg, calendar.fg))
 
     else -- no current month showing, no day to highlight
        local month = tonumber(os.date('%m'))
@@ -101,7 +101,7 @@ end
 function calendar:attach(widget, args)
     local args = args or {}
 
-    calendar.cal         = args.cal or "/usr/bin/cal"
+    calendar.cal         = args.cal or "/usr/bin/cal --color=always"
     calendar.icons       = args.icons or icons_dir .. "cal/white/"
     calendar.font        = args.font or beautiful.font:gsub(" %d.*", "")
     calendar.font_size   = tonumber(args.font_size) or 11


### PR DESCRIPTION
This fixes a calendar highlighting bug that I noticed earlier today (April 16):

![lain-calendar](https://cloud.githubusercontent.com/assets/18357704/14583452/6ab38d32-03f0-11e6-97ff-06ca4b032334.png)

I use `cal -w` to show the week numbers, and the week number 16 was incorrectly highlighted instead of the day. This patch fixes the bug by letting `cal` itself do the highlighting by passing `--color=always` and replacing the reverse-video escape codes with <span> markup. This is how it looks with the patch:

![lain-calendar-fixed](https://cloud.githubusercontent.com/assets/18357704/14583478/e29a0772-03f0-11e6-8b2d-e2c49845b949.png)

I tested all the command-line options for `cal` on Arch Linux, and the only escape codes it emits are for reverse video, so this won't lead to any garbage characters getting through unless there is a non-standard `cal` installed. Calendar widgets created with a user-defined command will need to be updated to include `--color=always`.