### PR TITLE
Support for multiple interfaces on net widget

### DIFF
--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -21,13 +21,13 @@ local setmetatable = setmetatable
 -- lain.widgets.net
 
 local function worker(args)
-    local net = { last_t = 0, last_r = 0 }
+    local net = { last_t = 0, last_r = 0, devices = {} }
 
-    function net.get_device()
+    function net.get_first_device()
         local ws = helpers.read_pipe("ip link show | cut -d' ' -f2,9")
         ws = ws:match("%w+: UP") or ws:match("ppp%w+: UNKNOWN")
-        if ws  then return ws:match("(%w+):")
-        else return "network off" end
+        if ws then return { ws:match("(%w+):") }
+        else return {} end
     end
 
     local args     = args or {}
@@ -36,53 +36,103 @@ local function worker(args)
     local notify   = args.notify or "on"
     local screen   = args.screen or 1
     local settings = args.settings or function() end
-    local iface    = args.iface or net.get_device()
+    local iface    = args.iface or net.get_first_device()
 
     net.widget = wibox.widget.textbox('')
 
-    helpers.set_map(iface, true)
+    -- Compatibility with old API where iface was a string corresponding to 1 interface
+    if type(iface) == "string" then
+        iftable = {iface}
+    else
+        iftable = iface
+    end
+
+    -- Mark all devices as initially online/active
+    for i, dev in ipairs(iftable) do
+        helpers.set_map(dev, true)
+    end
 
     function update()
-        net_now = {}
-
-        if iface == "" or string.match(iface, "network off")
-        then
-            iface = net.get_device()
+        -- This check is required to ensure we keep looking for one device if
+        -- none is found by net.get_first_device() at startup (i.e. iftable = {})
+        if next(iftable) == nil then
+            iftable = net.get_first_device()
         end
 
-        net_now.carrier  = helpers.first_line(string.format('/sys/class/net/%s/carrier', iface)) or '0'
-        net_now.state    = helpers.first_line(string.format('/sys/class/net/%s/operstate', iface)) or 'down'
+        -- These are the totals over all specified interfaces
+        net_now = {
+            -- New api - Current state of requested devices
+            devices  = {},
+            -- Bytes since last iteration
+            sent     = 0,
+            received = 0
+        }
 
-        local now_t      = helpers.first_line(string.format('/sys/class/net/%s/statistics/tx_bytes', iface)) or 0
-        local now_r      = helpers.first_line(string.format('/sys/class/net/%s/statistics/rx_bytes', iface)) or 0
+        -- Total bytes transfered
+        local total_t = 0
+        local total_r = 0
 
-        if now_t ~= net.last_t or now_r ~= net.last_r then
-            net_now.sent     = (now_t - net.last_t) / timeout / units
+        for i, dev in ipairs(iftable) do
+            local dev_now = {}
+            local dev_before = net.devices[dev] or { last_t = 0, last_r = 0 }
+
+            dev_now.carrier  = helpers.first_line(string.format('/sys/class/net/%s/carrier', dev)) or '0'
+            dev_now.state    = helpers.first_line(string.format('/sys/class/net/%s/operstate', dev)) or 'down'
+
+            local now_t      = tonumber(helpers.first_line(string.format('/sys/class/net/%s/statistics/tx_bytes', dev)) or 0)
+            local now_r      = tonumber(helpers.first_line(string.format('/sys/class/net/%s/statistics/rx_bytes', dev)) or 0)
+
+            dev_now.sent     = (now_t - dev_before.last_t) / timeout / units
+            dev_now.received = (now_r - dev_before.last_r) / timeout / units
+
+            net_now.sent     = net_now.sent     + dev_now.sent
+            net_now.received = net_now.received + dev_now.received
+
+            dev_now.sent     = string.gsub(string.format('%.1f', dev_now.sent), ',', '.')
+            dev_now.received = string.gsub(string.format('%.1f', dev_now.received), ',', '.')
+
+            dev_now.last_t   = now_t
+            dev_now.last_r   = now_r
+
+            -- This will become dev_before in the next update/iteration
+            net.devices[dev] = dev_now
+
+            total_t  = total_t + now_t
+            total_r  = total_r + now_r
+
+            -- Notify only once when connection is loss
+            if string.match(dev_now.carrier, "0") and notify == "on" and helpers.get_map(dev) then
+                naughty.notify({
+                    title    = dev,
+                    text     = "no carrier",
+                    icon     = helpers.icons_dir .. "no_net.png",
+                    screen   = screen
+                })
+                helpers.set_map(dev, false)
+            elseif string.match(dev_now.carrier, "1") then
+                helpers.set_map(dev, true)
+            end
+
+            -- Old api compatibility
+            net_now.carrier      = dev_now.carrier
+            net_now.state        = dev_now.state
+            -- And new api
+            net_now.devices[dev] = dev_now
+            -- With the new api new_now.sent and net_now.received will be the
+            -- totals across all specified devices
+
+        end
+
+        if total_t ~= net.last_t or total_r ~= net.last_r then
+            -- Convert to a string to round the digits after the float point
             net_now.sent     = string.gsub(string.format('%.1f', net_now.sent), ',', '.')
-            net_now.received = (now_r - net.last_r) / timeout / units
             net_now.received = string.gsub(string.format('%.1f', net_now.received), ',', '.')
 
             widget = net.widget
             settings()
 
-            net.last_t = now_t
-            net.last_r = now_r
-        end
-
-        if not string.match(net_now.carrier, "1") and notify == "on"
-        then
-            if helpers.get_map(iface)
-            then
-                naughty.notify({
-                    title    = iface,
-                    text     = "no carrier",
-                    icon     = helpers.icons_dir .. "no_net.png",
-                    screen   = screen
-                })
-                helpers.set_map(iface, false)
-            end
-        else
-            helpers.set_map(iface, true)
+            net.last_t = total_t
+            net.last_r = total_r
         end
     end
 


### PR DESCRIPTION
Addresses issue #191 by accepting an array if interface names via `args.iface`.

Compatibility with old API was kept by detecting if a string was passed.

Further testing with multiple devices is welcome.