### PR TITLE
mpd: make notifications hideable in widget config

### DIFF
--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -37,6 +37,7 @@ local function worker(args)
     local music_dir   = args.music_dir or os.getenv("HOME") .. "/Music"
     local cover_size  = args.cover_size or 100
     local default_art = args.default_art or ""
+    local show_notifications = args.show_notifications == true
     local followmouse = args.followmouse or false
     local echo_cmd    = args.echo_cmd or "echo"
     local settings    = args.settings or function() end
@@ -90,7 +91,7 @@ local function worker(args)
 
             if mpd_now.state == "play"
             then
-                if mpd_now.title ~= helpers.get_map("current mpd track")
+                if show_notifications and mpd_now.title ~= helpers.get_map("current mpd track")
                 then
                     helpers.set_map("current mpd track", mpd_now.title)
 


### PR DESCRIPTION
I personally find notifications on every song change too disturbing. So I only want to add the widget to the bar, which shows the current song info, and I can look there if it interests me.