### PR TITLE
MPD: add playlist position and mode flags

### DIFF
--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -58,28 +58,28 @@ local function worker(args)
     function mpd.update()
         async.request(echo .. " | curl --connect-timeout 1 -fsm 3 " .. mpdh, function (f)
             mpd_now = {
-                state   = "N/A",
-                file    = "N/A",
-                name    = "N/A",
-                artist  = "N/A",
-                title   = "N/A",
-                album   = "N/A",
-                date    = "N/A",
-                time    = "N/A",
-                elapsed = "N/A"
+                state        = "N/A",
+                file         = "N/A",
+                name         = "N/A",
+                artist       = "N/A",
+                title        = "N/A",
+                album        = "N/A",
+                date         = "N/A",
+                time         = "N/A",
+                elapsed      = "N/A"
             }
 
             for line in string.gmatch(f, "[^\n]+") do
                 for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
-                    if     k == "state"   then mpd_now.state   = v
-                    elseif k == "file"    then mpd_now.file    = v
-                    elseif k == "Name"    then mpd_now.name    = escape_f(v)
-                    elseif k == "Artist"  then mpd_now.artist  = escape_f(v)
-                    elseif k == "Title"   then mpd_now.title   = escape_f(v)
-                    elseif k == "Album"   then mpd_now.album   = escape_f(v)
-                    elseif k == "Date"    then mpd_now.date    = escape_f(v)
-                    elseif k == "Time"    then mpd_now.time    = v
-                    elseif k == "elapsed" then mpd_now.elapsed = string.match(v, "%d+")
+                    if     k == "state"          then mpd_now.state        = v
+                    elseif k == "file"           then mpd_now.file         = v
+                    elseif k == "Name"           then mpd_now.name         = escape_f(v)
+                    elseif k == "Artist"         then mpd_now.artist       = escape_f(v)
+                    elseif k == "Title"          then mpd_now.title        = escape_f(v)
+                    elseif k == "Album"          then mpd_now.album        = escape_f(v)
+                    elseif k == "Date"           then mpd_now.date         = escape_f(v)
+                    elseif k == "Time"           then mpd_now.time         = v
+                    elseif k == "elapsed"        then mpd_now.elapsed      = string.match(v, "%d+")
                     end
                 end
             end

--- a/widgets/mpd.lua
+++ b/widgets/mpd.lua
@@ -58,6 +58,12 @@ local function worker(args)
     function mpd.update()
         async.request(echo .. " | curl --connect-timeout 1 -fsm 3 " .. mpdh, function (f)
             mpd_now = {
+                random_mode  = false,
+                single_mode  = false,
+                repeat_mode  = false,
+                consume_mode = false,
+                pls_pos      = "N/A",
+                pls_len      = "N/A",
                 state        = "N/A",
                 file         = "N/A",
                 name         = "N/A",
@@ -80,6 +86,12 @@ local function worker(args)
                     elseif k == "Date"           then mpd_now.date         = escape_f(v)
                     elseif k == "Time"           then mpd_now.time         = v
                     elseif k == "elapsed"        then mpd_now.elapsed      = string.match(v, "%d+")
+                    elseif k == "song"           then mpd_now.pls_pos      = v
+                    elseif k == "playlistlength" then mpd_now.pls_len      = v
+                    elseif k == "repeat"         then mpd_now.repeat_mode  = v ~= "0"
+                    elseif k == "single"         then mpd_now.single_mode  = v ~= "0"
+                    elseif k == "random"         then mpd_now.random_mode  = v ~= "0"
+                    elseif k == "consume"        then mpd_now.consume_mode = v ~= "0"
                     end
                 end
             end


### PR DESCRIPTION
This adds the following information to the `mpd_now` table:

- pls_len (length of playlist)
- pls_pos (current position in playlist)
- single_mode (`true` if single mode is switched on, else `false`)
- repeat_mode (`true` if repeat mode is switched on, else `false`)
- random_mode (`true` if random mode is switched on, else `false`)
- consume_mode (`true` if consume mode is switched on, else `false`)