### PR TITLE
Two bugfixes on Thinkpad X260

### DIFF
--- a/widgets/bat.lua
+++ b/widgets/bat.lua
@@ -131,7 +131,7 @@ local function worker(args)
 
                 local hours     = math.floor(rate_time)
                 local minutes   = math.floor((rate_time - hours) * 60)
-                bat_now.perc    = tonumber(string.format("%d", math.min(100, sum_energy_percentage / #batteries)))
+                bat_now.perc    = tonumber(string.format("%d", math.floor(math.min(100, sum_energy_percentage / #batteries))))
                 bat_now.time    = string.format("%02d:%02d", hours, minutes)
                 bat_now.watt    = tonumber(string.format("%.2f", sum_rate_energy / 1e6))
             elseif bat_now.status == "Full" then

--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -128,12 +128,12 @@ local function worker(args)
             net_now.sent     = string.gsub(string.format('%.1f', net_now.sent), ',', '.')
             net_now.received = string.gsub(string.format('%.1f', net_now.received), ',', '.')
 
-            widget = net.widget
-            settings()
-
             net.last_t = total_t
             net.last_r = total_r
         end
+
+        widget = net.widget
+        settings()
     end
 
     helpers.newtimer(iface, timeout, update)


### PR DESCRIPTION
1) If we have two batteries, percentage can be float which cause an arror in awesome because of %d format string. So i just rounded the value to remove a error.
2) When my laptop is just started, it has 0 packets sent and received via net interfaces, and because of that  net widget looks totally empty. We need to call settings() even if we have zero packets sent/received.