### PR TITLE
task widget: make command line configurable

### DIFF
--- a/widgets/contrib/task.lua
+++ b/widgets/contrib/task.lua
@@ -43,7 +43,7 @@ function task:show(scr_pos)
         local scrp = scr_pos or task.scr_pos
     end
 
-    f = io.popen('task')
+    f = io.popen('task ' .. task.cmdline)
     c_text = "<span font='"
              .. task.font .. " "
              .. task.font_size .. "'>"
@@ -133,6 +133,7 @@ function task:attach(widget, args)
     task.timeout     = args.timeout or 7
     task.scr_pos     = args.scr_pos or 1
     task.followmouse = args.followmouse or false
+    task.cmdline     = args.cmdline or "next"
 
     task.notify_icon = icons_dir .. "/taskwarrior/task.png"
     task.notify_icon_small = icons_dir .. "/taskwarrior/tasksmall.png"


### PR DESCRIPTION
The default task report (`task next`) looks a bit bulky in my opinion:

![task next in naughty popup](https://gist.githubusercontent.com/rohieb/00e816749f7d5e69b0864ba84f1224b6/raw/99922523e08d3a4991874bf1a5120d5fbc309b63/30a0ed36-49d4-11e6-a1d2-979d4d215f80.png)

I use the task view popup mostly to get an overview of my tasks, and I find one line per task much more readable. So I configured a slimmer report view in my `~/.taskrc`:
```
report.nextpopup.columns      = id,depends.count,priority,project,tags,due.relative,description.truncated_count,urgency
report.nextpopup.description  = Most urgent tasks, one line each
report.nextpopup.filter       = status:pending limit:page
report.nextpopup.labels       = ID,Deps,P,Project,Tag,Due,Description,Urg
report.nextpopup.sort         = urgency-
```

With this patch, I can now add `cmdline = "nextpopup"` (and also some filters if I want) to my task widget setup, and the popup looks much better-arranged:

![task popup](https://gist.github.com/rohieb/00e816749f7d5e69b0864ba84f1224b6/raw/99922523e08d3a4991874bf1a5120d5fbc309b63/a010d19e-49d5-11e6-ac49-ff9aaf4bb6e2.png)