### PR TITLE
Two bugfixes(fs_widget + task _widget)

### DIFF
--- a/widgets/contrib/task.lua
+++ b/widgets/contrib/task.lua
@@ -25,6 +25,11 @@ local task = {}
 
 local task_notification = nil
 
+function findLast(haystack, needle)
+    local i=haystack:match(".*"..needle.."()")
+    if i==nil then return nil else return i-1 end
+end
+
 function task:hide()
     if task_notification ~= nil then
         naughty.destroy(task_notification)
@@ -125,8 +130,8 @@ function task:attach(widget, args)
     local args       = args or {}
 
     task.font_size   = tonumber(args.font_size) or 12
-    task.font        = beautiful.font:sub(beautiful.font:find(""),
-                       beautiful.font:find(" "))
+    task.font        = args.font or beautiful.font:sub(beautiful.font:find(""),
+                       findLast(beautiful.font, " "))
     task.fg          = args.fg or beautiful.fg_normal or "#FFFFFF"
     task.bg          = args.bg or beautiful.bg_normal or "#FFFFFF"
     task.position    = args.position or "top_right"

--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -58,6 +58,8 @@ local function worker(args)
     local args             = args or {}
     local timeout          = args.timeout or 600
     local partition        = args.partition or "/"
+    local showpopup        = args.showpopup or "on"
+    local notify           = args.notify or "on"
     local settings         = args.settings or function() end
 
     fs.followmouse         = args.followmouse or false
@@ -96,7 +98,7 @@ local function worker(args)
         widget = fs.widget
         settings()
 
-        if fs_now.used >= 99 and not helpers.get_map(partition)
+        if notify == "on" and fs_now.used >= 99 and not helpers.get_map(partition)
         then
             naughty.notify({
                 title = "warning",
@@ -111,8 +113,10 @@ local function worker(args)
         end
     end
 
-    fs.widget:connect_signal('mouse::enter', function () fs:show(0) end)
-    fs.widget:connect_signal('mouse::leave', function () fs:hide() end)
+    if showpopup == "on" then
+        fs.widget:connect_signal('mouse::enter', function () fs:show(0) end)
+        fs.widget:connect_signal('mouse::leave', function () fs:hide() end)
+    end
 
     helpers.newtimer(partition, timeout, update)
 


### PR DESCRIPTION
### fs widget
Naughty notification and popup now configurable in FS widget:
```lua
fs_widget = lain.widgets.fs({
        partition = "/"
        notify = "off",
        showpopup = "off",
        settings = function()
                widget:set_markup(fs_now.used  .. "%")
        end
})      
```
You must update wiki and add two configuration vlaues accordinly:

Variable | Meaning | Type | Default
--- | --- | --- | ---
`notify` | Display "partition is empty" notifications | string | "on"
`showpopup` | Display pop-up window with df output | string | "on"

If `notify = "off"` is set, the widget won't display a notification.
If `showpopup = "off"` is set, the widget won't display a pop-up.

### tasks widget
Add ability to specify font name in widget:
```lua
task_widget = wibox.widget.textbox("Task")
local task = require("lain.widgets.contrib.task")
task:attach( task_widget, {
        timeout = 7,
        position = "bottom_right",
        font = "Pragmata Pro",
        font_size = 11
})
```
Widget option must be also added to wiki:

Variable | Meaning | Type | Default
--- | --- | --- | ---
`font` | Pop-up font | string | beautiful.font


Also i made a bug fix, where font names with spaces like "Pragmata Pro" cannot be found by parsing beautiful.font. I`ve added own function to find last space properly.