### PR TITLE
Add used memory percentage

### DIFF
--- a/widgets/mem.lua
+++ b/widgets/mem.lua
@@ -46,6 +46,7 @@ local function worker(args)
 
         mem_now.used = mem_now.total - (mem_now.free + mem_now.buf + mem_now.cache)
         mem_now.swapused = mem_now.swap - mem_now.swapf
+	mem_now.perc = math.floor(mem_now.used / mem_now.total * 100)
 
         widget = mem.widget
         settings()


### PR DESCRIPTION
It's very common way to indicate memory usage via percentage. I'm surprised that there is no such variable.

Now memory widget can be initialized like this:
```lua
ram_widget = lain.widgets.mem({
				 settings = function()
				    widget:set_markup("RAM: " .. mem_now.perc .. "%")
				    end
			      })
```