### PR TITLE
Fixed notification screen bug in task widget

### DIFF
--- a/widgets/contrib/task.lua
+++ b/widgets/contrib/task.lua
@@ -40,12 +40,12 @@ end
 function task:show(scr_pos)
     task:hide()
 
-    local f, c_text
+    local f, c_text, scrp
 
     if task.followmouse then
-        local scrp = mouse.screen
+        scrp = mouse.screen
     else
-        local scrp = scr_pos or task.scr_pos
+        scrp = scr_pos or task.scr_pos
     end
 
     f = io.popen('task ' .. task.cmdline)


### PR DESCRIPTION
On multi-monitor setups, the task widget would always display notifications on screen 1 even when `followmouse` was set to true. The variable which set the screen value was localized in an if statement and was thus always nil when it was called later:

```lua
if task.followmouse then
    local scrp = mouse.screen
else
    local scrp = scr_pos or task.scr_pos
end
```

Pre-declaring the variable and unlocalizing it makes it work correctly.