### PR TITLE
widget.base: Fix cached output

### DIFF
--- a/widgets/base.lua
+++ b/widgets/base.lua
@@ -26,8 +26,8 @@ local function worker(args)
     base.widget = wibox.widget.textbox('')
 
     function base.update()
+        output = read_pipe(cmd)
         if output ~= base.prev then
-            output = read_pipe(cmd)
             widget = base.widget
             settings()
             base.prev = output


### PR DESCRIPTION
chicken or the egg syndrome, output is never declared, thus comparison always fails, so output is never assigned to the output of read_pipe, which results in the comparison failing which in turn ...