### PR TITLE
Add additional mouse controls to pulsebar

### DIFF
--- a/widgets/pulsebar.lua
+++ b/widgets/pulsebar.lua
@@ -27,6 +27,7 @@ local setmetatable = setmetatable
 -- lain.widgets.pulsebar
 local pulsebar = {
     sink = 0,
+    step = "5%",
 
     colors = {
         background = beautiful.bg_normal,
@@ -105,6 +106,7 @@ local function worker(args)
     pulsebar.colors        = args.colors or pulsebar.colors
     pulsebar.notifications = args.notifications or pulsebar.notifications
     pulsebar.sink          = args.sink or 0
+    pulsebar.step          = args.step or pulsebar.step
     pulsebar.followmouse   = args.followmouse or false
 
     pulsebar.bar = awful.widget.progressbar()
@@ -151,7 +153,23 @@ local function worker(args)
     pulsebar.bar:buttons (awful.util.table.join (
           awful.button ({}, 1, function()
             awful.util.spawn(pulsebar.mixer)
-          end)
+          end),
+          awful.button ({}, 2, function()
+						awful.util.spawn(string.format("pactl set-sink-lolume %d 100%%", pulsebar.sink))
+            pulsebar.update()
+          end),
+          awful.button ({}, 3, function()
+						awful.util.spawn(string.format("pactl set-sink-mute %d toggle", pulsebar.sink))
+            pulsebar.update()
+          end),
+          awful.button ({}, 4, function()
+						awful.util.spawn(string.format("pactl set-sink-volume %d +%s", pulsebar.sink, pulsebar.step))
+            pulsebar.update()
+          end),
+          awful.button ({}, 5, function()
+						awful.util.spawn(string.format("pactl set-sink-volume %d -%s", pulsebar.sink, pulsebar.step))
+            pulsebar.update()
+					end)
     ))
 
     timer_id = string.format("pulsebar-%s", pulsebar.sink)


### PR DESCRIPTION
Just like the alsabar widget:
- Scrollwheel increases and decreases volume
- Right click mutes
- Middle click sets volume to 100%
