### PR TITLE
Add fstype and exclude_fstype options 

### DIFF
--- a/scripts/dfs
+++ b/scripts/dfs
@@ -11,10 +11,11 @@
 # -------------------------------------------------------------------------
 #   Decoding options
 # -------------------------------------------------------------------------
-USAGE="Usage: $0 [-h(elp)] | [-n(arrow mode)] | [-w(eb output)]"
+USAGE="Usage: $0 [-h(elp)] | [-n(arrow mode)] | [-w(eb output) | --type=<fstype> | --exclude-type=<fstype>]"
 
 NARROW_MODE=0
 WEB_OUTPUT=0
+DF_OPTIONS=""
 
 while [ $# -gt 0 ]; do
 case "$1" in
@@ -30,6 +31,12 @@ NARROW_MODE=1
 ;;
 "-w" )
 WEB_OUTPUT=1
+;;
+--type=*)
+DF_OPTIONS+=" $1"
+;;
+--exclude-type=*)
+DF_OPTIONS+=" $1"
 ;;
 * )
 echo $USAGE
@@ -57,6 +64,9 @@ SORT_COMMAND="/usr/bin/sort -k6"
 AWK_COMMAND="/usr/bin/env gawk"
 ;;
 esac
+
+# Add additional df options
+DF_COMMAND+=$DF_OPTIONS
 
 # -------------------------------------------------------------------------
 #   Grabbing "df" result

--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -38,7 +38,15 @@ end
 function fs:show(t_out)
     fs:hide()
 
-    local ws = helpers.read_pipe(helpers.scripts_dir .. "dfs"):gsub("\n*$", "")
+    local cmd = "dfs"
+    if fs.fstype then
+      cmd = cmd .. " --type=" .. fs.fstype
+    end
+    if fs.exclude_fstype then
+      cmd = cmd .. " --exclude-type=" .. fs.exclude_fstype
+    end
+
+    local ws = helpers.read_pipe(helpers.scripts_dir .. cmd):gsub("\n*$", "")
 
     if fs.followmouse then
         fs.notification_preset.screen = mouse.screen
@@ -62,6 +70,8 @@ local function worker(args)
     local notify           = args.notify or "on"
     local settings         = args.settings or function() end
 
+    fs.fstype              = args.fstype or false
+    fs.exclude_fstype      = args.exclude_fstype or false
     fs.followmouse         = args.followmouse or false
     fs.notification_preset = args.notification_preset or { fg = beautiful.fg_normal }
 


### PR DESCRIPTION
These get passed to the dfs script and df to limit the display of the fs widget to specific filesystem types.