### PR TITLE
Fixed fs widget showing error messages on mouseover

### DIFF
--- a/widgets/fs.lua
+++ b/widgets/fs.lua
@@ -44,7 +44,7 @@ function fs.show(seconds, options, scr)
     if fs.followmouse then
         fs.notification_preset.screen = mouse.screen
     elseif scr then
-			  fs.notification_preset.screen = scr
+	    fs.notification_preset.screen = scr
     end
 
     fs_notification = naughty.notify({
@@ -117,8 +117,8 @@ local function worker(args)
     end
 
     if showpopup == "on" then
-        fs.widget:connect_signal('mouse::enter', function () fs:show(0) end)
-        fs.widget:connect_signal('mouse::leave', function () fs:hide() end)
+        fs.widget:connect_signal('mouse::enter', function () fs.show(0) end)
+        fs.widget:connect_signal('mouse::leave', function () fs.hide() end)
     end
 
     helpers.newtimer(partition, timeout, update)


### PR DESCRIPTION
Everytime the mouse has been moved over the file system widget, an error message ("/usr/share/awesome/lib/naughty.lua:342: attempt to compare number with table") appeared instead of the file system info. Fixed by the attached changes.