### PR TITLE
fixing redshit spawn_with_shell to be compliant with awesome v4.0

### DIFF
--- a/widgets/contrib/redshift.lua
+++ b/widgets/contrib/redshift.lua
@@ -25,9 +25,9 @@ local function init()
     -- toggled off (i.e Awesome on-the-fly restart), kill redshift to make sure
     os.execute("pkill redshift")
     -- Remove existing color adjustment
-    awful.spawn_with_shell("redshift -x")
+    awful.util.spawn_with_shell("redshift -x")
     -- (Re)start redshift
-    awful.spawn_with_shell("redshift")
+    awful.util.spawn_with_shell("redshift")
     running = true
     active = true
 end

--- a/widgets/contrib/redshift.lua
+++ b/widgets/contrib/redshift.lua
@@ -25,9 +25,9 @@ local function init()
     -- toggled off (i.e Awesome on-the-fly restart), kill redshift to make sure
     os.execute("pkill redshift")
     -- Remove existing color adjustment
-    awful.util.spawn_with_shell("redshift -x")
+    awful.spawn.with_shell("redshift -x")
     -- (Re)start redshift
-    awful.util.spawn_with_shell("redshift")
+    awful.spawn.with_shell("redshift")
     running = true
     active = true
 end


### PR DESCRIPTION
Old redshift used `awful.spawn_with_shell` which is now `awful.util.spawn_with_shell`