### PR TITLE
Generic shebang in scripts/dfs

### DIFF
--- a/scripts/dfs
+++ b/scripts/dfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #   Adapted from Eridan's "fs" (cleanup, enhancements and switch to bash/Linux)
 #   JM,  10/12/2004


### PR DESCRIPTION
Some systems have bash at locations other than /usr/bin/bash
Relying on /usr/bin/env is the most compatible option.