### PR TITLE
Fix bug where net widget would not get the device name

### DIFF
--- a/widgets/net.lua
+++ b/widgets/net.lua
@@ -35,7 +35,7 @@ local function worker(args)
 
     function net.get_device()
         helpers.async(string.format("ip link show", device_cmd), function(ws)
-            ws = ws:match("(%w+): <BROADCAST,MULTICAST,.-,UP,LOWER_UP>")
+            ws = ws:match("(%w+): <BROADCAST,MULTICAST,.-UP,LOWER_UP>")
             net.iface = ws and { ws } or {}
         end)
     end


### PR DESCRIPTION
This happens because my output from ```ip link show``` doesn't have anything additional betweeen MULTICAST and UP.

example output:

```
2: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP>
```