### PR TITLE
Make amixer get information only from the selected channel

### DIFF
--- a/widgets/alsa.lua
+++ b/widgets/alsa.lua
@@ -23,8 +23,8 @@ local function worker(args)
     local timeout  = args.timeout or 5
     local settings = args.settings or function() end
 
-    alsa.cmd           = args.cmd or "amixer"
     alsa.channel       = args.channel or "Master"
+    alsa.cmd           = args.cmd or "amixer sget " .. alsa.channel
     alsa.togglechannel = args.togglechannel
 
     if alsa.togglechannel then


### PR DESCRIPTION
Currently, the alsa widget parses information from `amixer`. This usually retrieves information of other unused channels (Capture, for example), and it harms the way the widget parses information. 

Without this patch, alsa widget isn't able to see whether a channel is mute or not, as it takes information from the last seen channel. With this patch, it retrieves information only from the selected channel. 