### PR TITLE
Fix base proxy widget

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -180,8 +180,7 @@ end
 -- create a textbox with no spacing issues
 function helpers.make_widget_textbox()
     local w = wibox.widget.textbox()
-    local t = wibox.widget.base.make_widget(w)
-    return setmetatable({widget = t}, { __index = w })
+    return {widget = w}
 end
 
 -- }}}

--- a/helpers.lua
+++ b/helpers.lua
@@ -181,8 +181,7 @@ end
 function helpers.make_widget_textbox()
     local w = wibox.widget.textbox()
     local t = wibox.widget.base.make_widget(w)
-    t.widget = w
-    return t
+    return setmetatable({widget = t}, { __index = w })
 end
 
 -- }}}


### PR DESCRIPTION
Since [a00417d8](https://github.com/copycat-killer/lain/commit/a00417d8011690d977cbdab1f1378ec369e5f355) all abase widgets inherit a proxy widget (from abase = helpers.make_widget_textbox(), instead of wibox.widget.textbox()) which ultimately causes the following problem (for EVERY widget):
```
2017-01-25 00:04:00 E: Error during a protected call: /usr/share/awesome/lib/wibox/widget/textbox.lua:45: attempt to index a nil value (field 'layout')
stack traceback:
	/usr/share/awesome/lib/wibox/widget/textbox.lua:45: in upvalue 'setup_layout'
	/usr/share/awesome/lib/wibox/widget/textbox.lua:52: in function 'wibox.widget.textbox.draw'
	[C]: in function 'xpcall'
	/usr/share/awesome/lib/gears/protected_call.lua:36: in function </usr/share/awesome/lib/gears/protected_call.lua:35>
	(...tail calls...)
	/usr/share/awesome/lib/wibox/hierarchy.lua:293: in local 'call'
	/usr/share/awesome/lib/wibox/hierarchy.lua:308: in function 'wibox.hierarchy.draw'
	/usr/share/awesome/lib/wibox/hierarchy.lua:315: in function 'wibox.hierarchy.draw'
	/usr/share/awesome/lib/wibox/hierarchy.lua:315: in function 'wibox.hierarchy.draw'
	/usr/share/awesome/lib/wibox/hierarchy.lua:315: in function 'wibox.hierarchy.draw'
	/usr/share/awesome/lib/wibox/hierarchy.lua:315: in function 'wibox.hierarchy.draw'
	/usr/share/awesome/lib/wibox/hierarchy.lua:315: in function 'wibox.hierarchy.draw'
	/usr/share/awesome/lib/wibox/drawable.lua:149: in upvalue 'do_redraw'
	/usr/share/awesome/lib/wibox/drawable.lua:374: in function </usr/share/awesome/lib/wibox/drawable.lua:372>
	[C]: in function 'xpcall'
	/usr/share/awesome/lib/gears/protected_call.lua:36: in function </usr/share/awesome/lib/gears/protected_call.lua:35>
	(...tail calls...)
	/usr/share/awesome/lib/gears/timer.lua:167: in function </usr/share/awesome/lib/gears/timer.lua:165>
```
After debugging it I got it to work deducing from what the rest of the code is expecting. I'm not familiar with the codebase and i could be entirely misdirected here but this whole problem seems like a code smell for something architecturally wrong. Please investigate the issue further.

I suggest not merging new code unless the output from running awesome is checked for errors (such as this one, which is quiet if you don't check the logs).