### PR TITLE
pulseaudio widget improvements

### DIFF
--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -16,9 +16,10 @@ local setmetatable = setmetatable
 
 -- PulseAudio volume
 -- lain.widgets.pulseaudio
-local pulseaudio = {}
+
 
 local function worker(args)
+   local pulseaudio = {}
    local args        = args or {}
    local timeout     = args.timeout or 5
    local settings    = args.settings or function() end
@@ -58,4 +59,4 @@ local function worker(args)
    return pulseaudio
 end
 
-return setmetatable(pulseaudio, { __call = function(_, ...) return worker(...) end })
+return setmetatable({}, { __call = function(_, ...) return worker(...) end })

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -21,8 +21,8 @@ local function factory(args)
     local args        = args or {}
     local devicetype  = args.devicetype or "sink"
     local timeout     = args.timeout or 5
-    local settings    = args.settings or function() end
     local scallback   = args.scallback
+    
     local cmd         = args.cmd or ("pacmd list-" .. devicetype .. "s | sed -n -e '/* index:/,/index:/ !d' -e '/* index:/ p' -e '/base volume:/ d' -e '/volume:/ p' -e '/muted:/ p' -e '/device\\.string/ p'")
     -- sed script explanation:
     --  '/* index:/,/index:/ !d' removes all lines outside of the range between the line containing '* index:' and the next line containing 'index:'. '* index:' denotes the beginning of the default device section.
@@ -31,7 +31,15 @@ local function factory(args)
     --  '/volume:/ p' prints the line containing 'volume:'.
     --  '/muted:/ p' prints the line containing 'muted:'.
     --  '/device\\.string/ p' prints the line containing 'device.string:'.
-
+    
+    local settings    = args.settings or function()
+            if volume_now.muted == "yes" then
+                widget:set_text("Mute")
+            else
+                widget:set_text(volume_now.left .. "%")
+            end
+        end
+        
     pulseaudio.widget = wibox.widget.textbox()
 
     function pulseaudio.update()

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -27,6 +27,7 @@ local function worker(args)
     local cmd         = args.cmd or ("pacmd list-" .. devicetype .. "s | sed -n -e '/* index:/,/index:/ !d' -e '/* index:/ p' -e '/base volume:/ d' -e '/volume:/ p' -e '/muted:/ p' -e '/device\\.string/ p'")
     
     pulseaudio.widget = wibox.widget.textbox()
+    pulseaudio.tooltip = awful.tooltip({ objects = { pulseaudio.widget } })
     
     function pulseaudio.update()
         if scallback then cmd = scallback() end
@@ -50,6 +51,7 @@ local function worker(args)
             volume_now.right = volume_now.channel[2] or "N/A"
 
             widget = pulseaudio.widget
+            tooltip = pulseaudio.tooltip
             
             settings()
         end)

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -24,7 +24,14 @@ local function factory(args)
    local settings    = args.settings or function() end
    local scallback   = args.scallback
 
-   pulseaudio.cmd    = args.cmd or "pacmd list-" .. devicetype .. "s | sed -n -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
+   pulseaudio.cmd    = args.cmd or ("pacmd list-" .. devicetype .. "s | sed -n -e '/* index:/,/index:/ !d' -e '/* index:/ p' -e '/base volume:/ d' -e '/volume:/ p' -e '/muted:/ p' -e '/device\\.string/ p'")
+    -- sed script explanation:
+    --  '/* index:/,/index:/ !d' removes all lines outside of the range between the line containing '* index:' and the next line containing 'index:'. '* index:' denotes the beginning of the default device section.
+    --  '/* index:/ p' prints the line containing '* index:'.
+    --  '/base volume:/ d' removes the line containing 'base volume:'. This is necessary due to the following script.
+    --  '/volume:/ p' prints the line containing 'volume:'.
+    --  '/muted:/ p' prints the line containing 'muted:'.
+    --  '/device\\.string/ p' prints the line containing 'device.string:'.
 
    pulseaudio.widget = wibox.widget.textbox()
 

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -7,7 +7,7 @@
 --]]
 
 local helpers      = require("lain.helpers")
-local shell        = require("awful.util").shell
+local awful        = require("awful")
 local wibox        = require("wibox")
 local string       = { gmatch = string.gmatch,
                        match  = string.match }
@@ -33,44 +33,49 @@ local function factory(args)
     --  '/device\\.string/ p' prints the line containing 'device.string:'.
     
     local settings    = args.settings or function()
+            widgettext  = volume_now.left .. "%"
+            tooltiptext = volume_now.left .. "% (" .. devicetype .. " " .. volume_now.index .. " \"" .. volume_now.device .. "\")"
             if volume_now.muted == "yes" then
-                widget:set_text("Mute")
-            else
-                widget:set_text(volume_now.left .. "%")
+                widgettext  = "Mute"
+                tooltiptext = "Mute/" .. tooltiptext
             end
+            widget:set_text(widgettext)
+            tooltip:set_text(tooltiptext)
         end
-        
+    
     pulseaudio.widget = wibox.widget.textbox()
-
+    pulseaudio.tooltip = awful.tooltip({ objects = { pulseaudio.widget } })
+    
     function pulseaudio.update()
         if scallback then cmd = scallback() end
-
-        helpers.async({ shell, "-c", cmd }, function(s)
+        
+        helpers.async({ awful.util.shell, "-c", cmd }, function(s)
             volume_now = {
                 index = string.match(s, "index: (%S+)") or "N/A",
                 device = string.match(s, "device.string = \"(%S+)\"") or "N/A",
                 sink   = device,  -- legacy API
                 muted  = string.match(s, "muted: (%S+)") or "N/A"
             }
-
+            
             local ch = 1
             volume_now.channel = {}
             for v in string.gmatch(s, ":.-(%d+)%%") do
                 volume_now.channel[ch] = v
                 ch = ch + 1
             end
-
+            
             volume_now.left  = volume_now.channel[1] or "N/A"
             volume_now.right = volume_now.channel[2] or "N/A"
 
             widget = pulseaudio.widget
+            tooltip = pulseaudio.tooltip
             
             settings()
         end)
     end
-
+    
     helpers.newtimer("pulseaudio", timeout, pulseaudio.update)
-
+    
     return pulseaudio
 end
 

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -10,15 +10,13 @@ local helpers      = require("lain.helpers")
 local shell        = require("awful.util").shell
 local wibox        = require("wibox")
 local string       = { gmatch = string.gmatch,
-                       match  = string.match,
-                       format = string.format }
-local setmetatable = setmetatable
+                       match  = string.match }
 
 -- PulseAudio volume
 -- lain.widgets.pulseaudio
 
 
-local function worker(args)
+local function factory(args)
    local pulseaudio = {}
    local args        = args or {}
    local timeout     = args.timeout or 5
@@ -59,4 +57,4 @@ local function worker(args)
    return pulseaudio
 end
 
-return setmetatable({}, { __call = function(_, ...) return worker(...) end })
+return factory

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -23,8 +23,7 @@ local function factory(args)
     local timeout     = args.timeout or 5
     local settings    = args.settings or function() end
     local scallback   = args.scallback
-
-    pulseaudio.cmd    = args.cmd or ("pacmd list-" .. devicetype .. "s | sed -n -e '/* index:/,/index:/ !d' -e '/* index:/ p' -e '/base volume:/ d' -e '/volume:/ p' -e '/muted:/ p' -e '/device\\.string/ p'")
+    local cmd         = args.cmd or ("pacmd list-" .. devicetype .. "s | sed -n -e '/* index:/,/index:/ !d' -e '/* index:/ p' -e '/base volume:/ d' -e '/volume:/ p' -e '/muted:/ p' -e '/device\\.string/ p'")
     -- sed script explanation:
     --  '/* index:/,/index:/ !d' removes all lines outside of the range between the line containing '* index:' and the next line containing 'index:'. '* index:' denotes the beginning of the default device section.
     --  '/* index:/ p' prints the line containing '* index:'.
@@ -36,9 +35,9 @@ local function factory(args)
     pulseaudio.widget = wibox.widget.textbox()
 
     function pulseaudio.update()
-        if scallback then pulseaudio.cmd = scallback() end
+        if scallback then cmd = scallback() end
 
-        helpers.async({ shell, "-c", pulseaudio.cmd }, function(s)
+        helpers.async({ shell, "-c", cmd }, function(s)
             volume_now = {
                 index = string.match(s, "index: (%S+)") or "N/A",
                 device = string.match(s, "device.string = \"(%S+)\"") or "N/A",

--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -19,11 +19,12 @@ local string       = { gmatch = string.gmatch,
 local function factory(args)
    local pulseaudio = {}
    local args        = args or {}
+   local devicetype  = args.devicetype or "sink"
    local timeout     = args.timeout or 5
    local settings    = args.settings or function() end
    local scallback   = args.scallback
 
-   pulseaudio.cmd    = args.cmd or "pacmd list-sinks | sed -n -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
+   pulseaudio.cmd    = args.cmd or "pacmd list-" .. devicetype .. "s | sed -n -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
 
    pulseaudio.widget = wibox.widget.textbox()
 
@@ -33,8 +34,9 @@ local function factory(args)
       helpers.async({ shell, "-c", pulseaudio.cmd }, function(s)
           volume_now = {
               index = string.match(s, "index: (%S+)") or "N/A",
-              sink  = string.match(s, "device.string = \"(%S+)\"") or "N/A",
-              muted = string.match(s, "muted: (%S+)") or "N/A"
+                device = string.match(s, "device.string = \"(%S+)\"") or "N/A",
+                sink   = device,  -- legacy API
+                muted  = string.match(s, "muted: (%S+)") or "N/A"
           }
 
           local ch = 1


### PR DESCRIPTION
(Preamble: This is my first pull request, so please be forgiving if I do some mistakes. -.-)

Hi there,
I wanted to use two pulseaudio widgets simultaneously in order to monitor the microphone sensivity as well, but the implementation did not handle multiple pulseaudio instances correctly. So I fixed this and also added an easy method to switch between the default pulseaudio sink (speaker) and source (microphone). From there on I also did some more improvements.

All in all I changed the following:
- Correct handling of multiple widget instances.
- Added option for source monitoring.
- Documented the sed command, as this will greatly aid anybody not familiar with sed. (like e.g. myself until just then)
- Created a default setting.
- Added tooltip support and a default tooltip.

Tested it myself using 
```
awesome v4.0 (Harder, Better, Faster, Stronger)
 • Compiled against Lua 5.3.3 (running with Lua 5.3)
 • D-Bus support: ✔
 • execinfo support: ✔
 • RandR 1.5 support: ✔
 • LGI version: 0.9.1
```