### PR TITLE
Weather widget broken again

### DIFF
--- a/widgets/weather.lua
+++ b/widgets/weather.lua
@@ -130,7 +130,13 @@ local function worker(args)
                 local icon    = weather_now["weather"][1]["icon"]
                 local loc_m   = os.time { year = os.date("%Y"), month = os.date("%m"), day = os.date("%d"), hour = 0 }
                 local offset  = utc_offset()
-                local utc_m   = loc_m + offset
+                local utc_m   = loc_m - offset
+
+                if offset > 0 and (now - utc_m)>=86400 then
+                    utc_m = utc_m + 86400
+                elseif offset < 0 and (utc_m - now)>=86400 then
+                    utc_m = utc_m - 86400
+                end
 
                 -- if we are 1 day after the GMT, return 1 day back, and viceversa
                 if offset > 0 and loc_m >= utc_m then


### PR DESCRIPTION
I've found you've removed all calls of ```read_pipe``` from code. Unfortunately it's caused a wrong time calculation in weather widget. So here is proposed fix 
1) a typo: one should subtract offset from local midnight to calculate UTC midnight
2) lua ```os.time``` behavior differs from system utility ```date```
``` date -u -d 'today 00:00:00' +'%%s' ``` calculates unix seconds for midnight in UTC time zone location, whereas os.time does it for midnight in local time zone. At some conditions (in my place - every day after 1PM) offset between these times becomes more then 24 hours and ````utc_m``` begins to point to yesterday.