### PR TITLE
Set widget item in pulseaudio table

### DIFF
--- a/widgets/pulseaudio.lua
+++ b/widgets/pulseaudio.lua
@@ -18,7 +18,7 @@ local setmetatable = setmetatable
 -- lain.widgets.pulseaudio
 
 local function worker(args)
-    local pulseaudio = { wibox.widget.textbox() }
+    local pulseaudio = { widget = wibox.widget.textbox() }
     local args        = args or {}
     local devicetype  = args.devicetype or "sink"
     local timeout     = args.timeout or 5


### PR DESCRIPTION
Without this the line below which exposes the widget variable to
the settings function as pulseaudio.widget will end up setting
the widget to nil, which is not very helpful.