### PR TITLE
Always display transfer rates as string

### DIFF
--- a/widget/net.lua
+++ b/widget/net.lua
@@ -103,12 +103,10 @@ local function factory(args)
             -- totals across all specified devices
         end
 
-        if total_t ~= net.last_t or total_r ~= net.last_r then
-            net_now.sent     = string.format('%.1f', net_now.sent)
-            net_now.received = string.format('%.1f', net_now.received)
-            net.last_t       = total_t
-            net.last_r       = total_r
-        end
+        net_now.sent     = string.format('%.1f', net_now.sent)
+        net_now.received = string.format('%.1f', net_now.received)
+        net.last_t       = total_t
+        net.last_r       = total_r
 
         widget = net.widget
         settings()


### PR DESCRIPTION
When all devices idle the widget returns 2 integer values.
When still something is measured the widget behaves in a rather "jumpy" way switching between "0 0" and "0.1 0.0" or similar values which makes the entire widget resize itself all the time.

The affected if clause was trying to avoid a tiny performance impact but the change shouldn't be noticeable.

This patch removes this check and always returns a float as a string.