### PR TITLE
Workaround premature end of file with awful.spawn.easy_async

### DIFF
--- a/scripts/dfs
+++ b/scripts/dfs
@@ -224,7 +224,7 @@ echo "$SORTED_FILE_SYSTEMS_INFO" | $AWK_COMMAND -v DEBUG=$DEBUG -v PATTERN=$PATT
 							 printf ("%-*s", LEFT_COLUMN + 2, "");
 					 print "                                                    Used     Free       Total ";
 					 if (! NARROW_MODE)
-						 print "";
+						 print " ";
 				 }
 			 }
 


### PR DESCRIPTION
After upgrading to awesome 4.0 I started seeing the behaviour described in this https://github.com/copycat-killer/lain/issues/272#issuecomment-280957778 .

It turns out to be an [upstream feature](https://github.com/awesomeWM/awesome/blob/master/lib/awful/spawn.lua#L188).

This tiny change prevents the premature end and restores normal behaviour.