### PR TITLE
Add device field to pulseaudio widget

### DIFF
--- a/widget/pulseaudio.lua
+++ b/widget/pulseaudio.lua
@@ -24,7 +24,8 @@ local function factory(args)
     local settings    = args.settings or function() end
     local scallback   = args.scallback
 
-    pulseaudio.cmd    = args.cmd or "pacmd list-" .. devicetype .. "s | sed -n -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
+    pulseaudio.device = "0"
+    pulseaudio.cmd    = args.cmd or "pacmd list-sinks | sed -n -e '/* index:/p' -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device.string/p' -e '/index:/,$d'"
 
     function pulseaudio.update()
         if scallback then pulseaudio.cmd = scallback() end
@@ -37,6 +38,8 @@ local function factory(args)
                 muted  = string.match(s, "muted: (%S+)") or "N/A"
             }
 
+            pulseaudio.device = volume_now.device
+        
             local ch = 1
             volume_now.channel = {}
             for v in string.gmatch(s, ":.-(%d+)%%") do

--- a/widget/pulseaudio.lua
+++ b/widget/pulseaudio.lua
@@ -38,7 +38,7 @@ local function factory(args)
                 muted  = string.match(s, "muted: (%S+)") or "N/A"
             }
 
-            pulseaudio.device = volume_now.device
+            pulseaudio.device = volume_now.index
         
             local ch = 1
             volume_now.channel = {}

--- a/widget/pulseaudio.lua
+++ b/widget/pulseaudio.lua
@@ -25,7 +25,7 @@ local function factory(args)
     local scallback   = args.scallback
 
     pulseaudio.device = "0"
-    pulseaudio.cmd    = args.cmd or "pacmd list-sinks | sed -n -e '/* index:/p' -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device.string/p' -e '/index:/,$d'"
+    pulseaudio.cmd    = args.cmd or "pacmd list-" .. devicetype .. "s | sed -n -e '/* index:/p' -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device.string/p' -e '/index:/,$d'"
 
     function pulseaudio.update()
         if scallback then pulseaudio.cmd = scallback() end


### PR DESCRIPTION
This allows the channel to be addressed in the same way as the alsa widget, from hotkeys in different packages.