### PR TITLE
scripts/dfs: specify bash instead of sh

### DIFF
--- a/scripts/dfs
+++ b/scripts/dfs
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 #   Adapted from Eridan's "fs" (cleanup, enhancements and switch to bash/Linux)
 #   JM,  10/12/2004


### PR DESCRIPTION
The `sh` on e.g. Debian is `dash`, but the script requires bash features by using `+=`. Until #272 is complete I think this is the best way to ensure that dfs works by default (excluding the gawk requirement).