### PR TITLE
quake: add a new option `onlyone`.

### DIFF
--- a/util/quake.lua
+++ b/util/quake.lua
@@ -27,6 +27,8 @@ local quake = {}
 
 function quake:display()
     if self.followtag then self.screen = awful.screen.focused() end
+    local toscan = self.screen
+    if self.onlyone then toscan = nil end
 
     -- First, we locate the client
     local client = nil
@@ -34,7 +36,7 @@ function quake:display()
     for c in awful.client.iterate(function (c)
         -- c.name may be changed!
         return c.instance == self.name
-    end, nil, self.screen)
+    end, nil, toscan)
     do
         i = i + 1
         if i == 1 then
@@ -128,6 +130,7 @@ function quake:new(config)
     conf.border     = conf.border    or 1          -- client border width
     conf.visible    = conf.visible   or false      -- initially not visible
     conf.followtag  = conf.followtag or false      -- spawn on currently focused screen
+    conf.onlyone    = conf.onlyone   or false      -- one instance for all screens
     conf.overlap    = conf.overlap   or false      -- overlap wibox
     conf.screen     = conf.screen    or awful.screen.focused()
     conf.settings   = conf.settings


### PR DESCRIPTION
This option allows using a single instance of the app with multiple
screens instead of having a separate app for each screen. It works
better if there is only one instance of the quake object, i.e.

    local quake = lain.util.quake({onlyone=true})

and

    awful.key({ modkey, }, "z", function () quake:toggle() end),