### PR TITLE
Short circuit notification check if fs_now.used is not a number

### DIFF
--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -93,7 +93,7 @@ local function factory(args)
             widget = fs.widget
             settings()
 
-            if notify == "on" and #fs_now.used > 0 and tonumber(fs_now.used) >= 99 and not helpers.get_map(partition) then
+            if notify == "on" and tonumber(fs_now.used) > 0 and tonumber(fs_now.used) >= 99 and not helpers.get_map(partition) then
                 naughty.notify({
                     preset = naughty.config.presets.critical,
                     title  = "Warning",

--- a/widget/fs.lua
+++ b/widget/fs.lua
@@ -93,7 +93,7 @@ local function factory(args)
             widget = fs.widget
             settings()
 
-            if notify == "on" and tonumber(fs_now.used) > 0 and tonumber(fs_now.used) >= 99 and not helpers.get_map(partition) then
+            if notify == "on" and tonumber(fs_now.used) and tonumber(fs_now.used) >= 99 and not helpers.get_map(partition) then
                 naughty.notify({
                     preset = naughty.config.presets.critical,
                     title  = "Warning",


### PR DESCRIPTION
I was getting a "tried to compare number with nil" error, presumably because fs_now.used was "N/A". 