### PR TITLE
provide a sane default for gpmdp's icon_size

### DIFF
--- a/widget/contrib/gpmdp.lua
+++ b/widget/contrib/gpmdp.lua
@@ -30,6 +30,7 @@ local function factory(args)
 
     gpmdp_notification_preset = {
         title   = "Now playing",
+        icon_size = 64,
         timeout = 6
     }
 


### PR DESCRIPTION
Without a reasonable default for icon_size you end up with notifications that basically cover the whole screen on a thinkpad x230 ;-).

You can easily change them with overriding gpmdp_notification_preset, but I don't think it should be necessary for the average user. Anybody who actually changed it won't be touched by this change.