### PR TITLE
Fix issue with `add_tag` when not using floating layout

### DIFF
--- a/util/init.lua
+++ b/util/init.lua
@@ -117,7 +117,7 @@ function util.add_tag(layout)
         textbox      = awful.screen.focused().mypromptbox.widget,
         exe_callback = function(name)
             if not name or #name == 0 then return end
-            awful.tag.add(name, { screen = awful.screen.focused(), layout = layout or awful.layout.layouts[0] }):view_only()
+            awful.tag.add(name, { screen = awful.screen.focused(), layout = layout or awful.layout.layouts[1] }):view_only()
         end
     }
 end


### PR DESCRIPTION
Using `awful.layout.layouts[0]` was causing `add_tag` to always be set to floating rather than the first entry in `awful.layout.layouts`. This would be fine for users who were using the floating layout, but would otherwise break the layoutbox widget and changing layouts.