### PR TITLE
mpd: Allow mpd connection via UNIX socket

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -144,10 +144,10 @@ end
 -- Probably just gonna leave it local for now
 function generate_buffer(buffer_length)
     -- First, create an output buffer to recieve from
-    local recv_buffer = ""
+    local recv_buffer = " "
     -- We'll need to allocate `buffer_length` bytes to it
     for i=1,buffer_length do
-        local recv_buffer = recv_buffer .. " "
+        recv_buffer = recv_buffer .. " "
     end
 
     return recv_buffer
@@ -189,9 +189,8 @@ function helpers.send_to_ip_address(ip_address, port, data, buffer_length)
                                 gio.SocketProtocol.DEFAULT)
 
     -- Create a socket address to connect to
-    local inet_addr = Gio.InetAddress.new_from_string(ip_address)
-    local addr = gio.UnixSocketAddress.new(inet_addr, port)
-
+    local inet_addr = gio.InetAddress.new_from_string(ip_address)
+    local addr = gio.InetSocketAddress.new(inet_addr, port)
     -- Connect across
     sock:connect(addr)
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -193,13 +193,11 @@ function helpers.send_to_ip_address(ip_address, port, data, buffer_length)
     local addr = gio.InetSocketAddress.new(inet_addr, port)
     -- Connect across
     sock:connect(addr)
-
     -- Send our message
     sock:send(data)
-
     -- Pull back anything it sends back
     sock:receive(recv_buffer)
-
+    sock:close()
     return recv_buffer
 end
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -15,6 +15,8 @@ local io         = { lines = io.lines,
 local rawget     = rawget
 local table      = { sort  = table.sort }
 
+local gio = require("lgi").Gio
+
 -- Lain helper functions for internal use
 -- lain.helpers
 local helpers = {}
@@ -133,6 +135,42 @@ function helpers.get_map(element)
 end
 
 -- }}}
+
+
+-- {{{ Network functions
+
+-- Send some data to a UNIX socket
+function helpers.send_to_unix_socket(unix_path, data, buffer_length) 
+    
+    -- First, create an output buffer to recieve from
+    local recv_buffer = ""
+    -- We'll need to allocate `buffer_length` bytes to it
+    for i=1,buffer_length do
+        recv_buffer = recv_bufer .. " "
+    end
+
+    -- Create a socket to send some data from
+    local sock = gio.Socket.new(gio.SocketFamily.UNIX,
+                                gio.SocketType.STREAM,
+                                gio.SocketProtocol.DEFAULT)
+
+    -- Create a socket address to connect to
+    local addr = gio.UnixSocketAddress.new(path)
+
+    -- Connect across
+    sock:connect(addr)
+    
+    -- Send our message
+    sock:send(data)
+
+    -- Pull back anything it sends back
+    sock:receive(recv_buffer)
+
+    return recv_buffer    
+end
+
+
+-- }}} 
 
 -- {{{ Misc
 

--- a/widget/mpd.lua
+++ b/widget/mpd.lua
@@ -16,7 +16,8 @@ local wibox        = require("wibox")
 local os           = { getenv = os.getenv }
 local string       = { format = string.format,
                        gmatch = string.gmatch,
-                       match  = string.match }
+                       match  = string.match,
+                       sub    = string.sub }
 
 -- MPD infos
 -- lain.widget.mpd
@@ -41,7 +42,7 @@ local function factory(args)
     local echo = string.format("printf \"%sstatus\\ncurrentsong\\nclose\\n\"", password)
    
     -- If host begins with "/", we can assume that it is a socket
-    if host.sub(host, 1, 1) == "/" then
+    if string.sub(host, 1, 1) == "/" then
         -- It's a socket, use socat to talk directly to it
         mpdh = string.format("UNIX-CONNECT:%s", host)
         cmd = string.format("%s | socat - %s", echo, mpdh)

--- a/widget/mpd.lua
+++ b/widget/mpd.lua
@@ -39,25 +39,14 @@ local function factory(args)
 
     local mpdh          = ""
     local cmd           = ""
-    local echo = string.format("printf \"%sstatus\\ncurrentsong\\nclose\\n\"", password)
+    local echo = string.format("%sstatus\ncurrentsong\nclose\n", password)
    
-    -- If host begins with "/", we can assume that it is a socket
-    if string.sub(host, 1, 1) == "/" then
-        -- It's a socket, use socat to talk directly to it
-        mpdh = string.format("UNIX-CONNECT:%s", host)
-        cmd = string.format("%s | socat - %s", echo, mpdh)
-    else
-        -- It's not a socket, assume IP or other host
-        mpdh = string.format("telnet://%s:%s", host, port)
-        cmd = string.format("%s | curl --connect-timeout 1 -fsm 3 %s", echo, mpdh)
-    end
-    
     mpd_notification_preset = { title = "Now playing", timeout = 6 }
 
     helpers.set_map("current mpd track", nil)
-
     function mpd.update()
-        helpers.async({ shell, "-c", cmd }, function(f)
+        helpers.send_to_address(host, port, echo, 10000, function(f)
+            local res = 0
             mpd_now = {
                 random_mode  = false,
                 single_mode  = false,

--- a/widget/mpd.lua
+++ b/widget/mpd.lua
@@ -46,7 +46,6 @@ local function factory(args)
     helpers.set_map("current mpd track", nil)
     function mpd.update()
         helpers.send_to_address(host, port, echo, 10000, function(f)
-            local res = 0
             mpd_now = {
                 random_mode  = false,
                 single_mode  = false,


### PR DESCRIPTION
Previously, the mpd widget couldn't communicate via a UNIX socket, leading to it being basically useless in that case.

We can use exactly the same command sent through `socat` to fix this, which this implements. 