### PR TITLE
Add devicetype to pulsebar to match pulseaudio and update sed command

### DIFF
--- a/widget/pulseaudio.lua
+++ b/widget/pulseaudio.lua
@@ -24,7 +24,7 @@ local function factory(args)
 
     pulseaudio.device = "N/A"
     pulseaudio.devicetype = args.devicetype or "sink"
-    pulseaudio.cmd = args.cmd or "pacmd list-" .. pulseaudio.devicetype .. "s | sed -n -e '0,/*/d' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
+    pulseaudio.cmd = args.cmd or "pacmd list-" .. pulseaudio.devicetype .. "s | sed -n -e '/*/,$!d' -e '/index/p' -e '/base volume/d' -e '/volume:/p' -e '/muted:/p' -e '/device\\.string/p'"
 
     function pulseaudio.update()
         if scallback then pulseaudio.cmd = scallback() end


### PR DESCRIPTION
It looks like `sink` was only used to display tooltips, but default `cmd` would use the default sink. So if you changed the default the tooltips would be incorrect.

I've updated pulsebar to work similar to the pulseaudio widget with `devicetype` and `device`, and updated the sed cmd which would would never set `device`.