### PR TITLE
Find CPU frequencies

### DIFF
--- a/widget/cpu.lua
+++ b/widget/cpu.lua
@@ -28,7 +28,7 @@ local function factory(args)
         for index,time in pairs(helpers.lines_match("cpu","/proc/stat")) do
             local coreid = index - 1
             local core   = cpu.core[coreid] or
-                           { last_active = 0 , last_total = 0, usage = 0 }
+                           { last_active = 0 , last_total = 0, usage = 0, frequency = 0 }
             local at     = 1
             local idle   = 0
             local total  = 0
@@ -60,8 +60,21 @@ local function factory(args)
             end
         end
 
+        -- Read the frequency at which the CPUs are operating
+        -- This info is found in /proc/cpuinfo
+        local freq_sum = 0
+        local cpu_count = 0
+        for coreid,line in pairs(helpers.lines_match("cpu MHz", "/proc/cpuinfo")) do
+            local frequency = tonumber(string.match(line, "%d+%.%d+"))
+            cpu.core[coreid].frequency = frequency
+            freq_sum = freq_sum + frequency
+            cpu_count = cpu_count + 1
+        end
+        cpu.core[0].frequency = freq_sum / cpu_count  -- coreid 0 is for average
+
         cpu_now = cpu.core
         cpu_now.usage = cpu_now[0].usage
+        cpu_now.frequency = cpu_now[0].frequency
         widget = cpu.widget
 
         settings()


### PR DESCRIPTION
This will add frequency data to the cpu widget. You use it in the same way as the usage. Example
```lua
average_freq = cpu_now.frequency
freq_2 = cpu_now[2].frequency
```

This would need a small modification to the cpu wiki page. I have not managed to figure out how to do that. Do I fork the wiki? How?