### PR TITLE
net: Use local variable devices instead of net.devices

### DIFF
--- a/widget/net.lua
+++ b/widget/net.lua
@@ -17,7 +17,8 @@ local string  = string
 local function factory(args)
     args             = args or {}
 
-    local net        = { widget = args.widget or wibox.widget.textbox(), devices = {} }
+    local net        = { widget = args.widget or wibox.widget.textbox() }
+    local devices    = {}
     local timeout    = args.timeout or 2
     local units      = args.units or 1024 -- KB
     local notify     = args.notify or "on"
@@ -51,7 +52,7 @@ local function factory(args)
 
         for _, dev in ipairs(net.iface) do
             local dev_now    = {}
-            local dev_before = net.devices[dev] or { last_t = 0, last_r = 0 }
+            local dev_before = devices[dev] or { last_t = 0, last_r = 0 }
             local now_t      = tonumber(helpers.first_line(string.format("/sys/class/net/%s/statistics/tx_bytes", dev)) or 0)
             local now_r      = tonumber(helpers.first_line(string.format("/sys/class/net/%s/statistics/rx_bytes", dev)) or 0)
 
@@ -85,7 +86,7 @@ local function factory(args)
                 dev_now.ethernet = false
             end
 
-            net.devices[dev] = dev_now
+            devices[dev] = dev_now
 
             -- Notify only once when connection is lost
             if string.match(dev_now.carrier, "0") and notify == "on" and helpers.get_map(dev) then


### PR DESCRIPTION
Using widget:set_markup in the setting function triggers the following error:

/usr/share/awesome/lib/gears/object.lua:189: Cannot set 'devices' on
wibox.widget.textbox (table: 0xXXXXX) because it is read-only.

This happens because of the definition of net:

	local net = { widget = args.widget or wibox.widget.textbox(), devices: {} }

The error complains about the devices field.

Everything works with widget:set_text, I suppose set_markup needs all the fields in the widget.

I have moved the table field to a local variable to allow using it with set_markup.