### PR TITLE
Add widget/contrib/btinfo.lua

### DIFF
--- a/lain-scm-1.rockspec
+++ b/lain-scm-1.rockspec
@@ -38,6 +38,7 @@ build = {
       ["lain.widget.contrib.redshift"] = "widget/contrib/redshift.lua",
       ["lain.widget.contrib.task"] = "widget/contrib/task.lua",
       ["lain.widget.contrib.tp_smapi"] = "widget/contrib/tp_smapi.lua",
+      ["lain.widget.contrib.btinfo"] = "widget/contrib/btinfo.lua",
       ["lain.widget.alsa"] = "widget/alsa.lua",
       ["lain.widget.alsabar"] = "widget/alsabar.lua",
       ["lain.widget.bat"] = "widget/bat.lua",

--- a/widget/contrib/btinfo.lua
+++ b/widget/contrib/btinfo.lua
@@ -1,0 +1,53 @@
+--[[
+
+     Licensed under GNU General Public License v2
+      * (c) 2025, Mehmet Tekman <http://github.com/mtekman>
+
+--]]
+
+local helpers      = require("lain.helpers")
+local wibox        = require("wibox")
+local string       = string
+
+-- Bluetooth battery
+-- lain.widget.contrib.btinfo
+
+local function factory(args)
+    args             = args or {}
+
+    local btinfo      = {widget = args.widget or wibox.widget.textbox()}
+    local timeout    = args.timeout or 10
+    local device_mac = args.device_mac or ""
+    local settings   = args.settings or function() end
+
+    function btinfo.update()
+       helpers.async(
+          string.format("bluetoothctl info '%s'", device_mac), function(f)
+             bt_now = {
+                name   = "N/A",
+                icon    = "N/A",
+                connected  = "N/A",
+                paired   = "N/A",
+                percentage  = "N/A"
+             }
+
+             for line in string.gmatch(f, "[^\n]+") do
+                for k, v in string.gmatch(line, "([%w]+):[%s](.*)$") do
+                   -- Matches only the last word before the colon in 'bluetoothctl info'
+                   if     k == "Name"       then bt_now.name = v
+                   elseif k == "Icon"       then bt_now.icon = v
+                   elseif k == "Connected"  then bt_now.connected = (v == "yes")
+                   elseif k == "Paired"     then bt_now.paired = (v == "yes")
+                   elseif k == "Percentage" then bt_now.percentage = tonumber(string.match(v, "%(%s*(%d+)%)"))
+                   end
+                end
+             end
+             widget = btinfo.widget
+             settings(bt_now)
+       end)
+    end
+    btinfo.timer = helpers.newtimer("btinfo", timeout, btinfo.update, false, true)
+    return btinfo
+end
+
+return factory

--- a/widget/contrib/btinfo.lua
+++ b/widget/contrib/btinfo.lua
@@ -1,6 +1,6 @@
 --[[
 
-     Licensed under GNU General Public License v2
+     Licensed under GNU General Public License v3
       * (c) 2025, Mehmet Tekman <http://github.com/mtekman>
 
 --]]
@@ -9,14 +9,14 @@ local helpers      = require("lain.helpers")
 local wibox        = require("wibox")
 local string       = string
 
--- Bluetooth battery
+-- Bluetooth Information
 -- lain.widget.contrib.btinfo
 
 local function factory(args)
     args             = args or {}
 
     local btinfo      = {widget = args.widget or wibox.widget.textbox()}
-    local timeout    = args.timeout or 10
+    local timeout    = args.timeout or 30
     local device_mac = args.device_mac or ""
     local settings   = args.settings or function() end
 


### PR DESCRIPTION
A small library to probe a bluetooth device of choice for information and to present it as widget. 

Wiki text added here: https://github.com/lcpz/lain/wiki/btinfo